### PR TITLE
Clean up build variants.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,2 @@
-[target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb --command=gdb.cfg -w'
-
 [build]
-target = "thumbv7em-none-eabihf"
+target = "thumbv6m-none-eabi"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.cargo.target": "thumbv6m-none-eabi"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "neotron_os"
+name = "neotron-os"
 version = "0.1.0"
 authors = ["Jonathan 'theJPster' Pallant <github@thejpster.org.uk>"]
 edition = "2018"
@@ -9,7 +9,17 @@ readme = "README.md"
 repository = "https://github.com/neotron-compute/Neotron-OS"
 
 [[bin]]
-name = "neotron_os"
+name = "flash1002"
+test = false
+bench = false
+
+[[bin]]
+name = "flash0802"
+test = false
+bench = false
+
+[[bin]]
+name = "flash0002"
 test = false
 bench = false
 

--- a/README.md
+++ b/README.md
@@ -19,48 +19,37 @@ This OS is a work in progress. We intend to support:
 
 ## Build instructions
 
-Your board will need an appropriate Neotron BIOS installed, and you need to have OpenOCD running for your particular board. You also need to set the linker 
-arguments so you link the binary to suit the memory available on your system.
+Your board will need an appropriate Neotron BIOS installed, and you need to
+have OpenOCD (or other programming tool) running for your particular board.
+You may also need to set the linker arguments so you link the binary to suit
+the memory available on your system.
 
-### Build Instructions for the Neotron Pico
-
-The Neotron Pico has some special memory requirements - in particular, the
-flash lives at `0x1000_0000` and not `0x0000_0000`. There is 1920 KiB of
-flash, and 240 KiB of RAM available.
+### Build Instructions for the Neotron Pico (and other systems with Flash at `0x1000_0000`)
 
 ```
 $ git clone https://github.com/neotron-compute/Neotron-OS.git
 $ cd Neotron-OS
 $ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-os-pico.ld" cargo build --release --target=thumbv6m-none-eabi
+$ RUSTFLAGS="-C link-arg=-Tneotron-flash-1000.ld" cargo build --release --target=thumbv6m-none-eabi
 ```
 
-### Build Instructions for 256K RAM systems
-
-Systems which reserve the second 512 KiB of Flash and first 256 KiB of SRAM
-for the OS can use this linker script. These systems include the Neotron
-340ST.
+### Build Instructions for the STM32 (and other systems with Flash at `0x0800_0000`)
 
 ```
 $ git clone https://github.com/neotron-compute/Neotron-OS.git
 $ cd Neotron-OS
 $ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-os-256k.ld" cargo run --release
+$ RUSTFLAGS="-C link-arg=-Tneotron-flash-0800.ld" cargo build --release --target=thumbv6m-none-eabi
 ```
 
-### Build Instructions for 32K RAM systems
-
-Systems which reserve the second 128 KiB of Flash and first 26 KiB of SRAM for
-the OS can use this linker script. These systems include the Neotron 32.
+### Build Instructions for other systems (with Flash at `0x0000_0000`)
 
 ```
 $ git clone https://github.com/neotron-compute/Neotron-OS.git
 $ cd Neotron-OS
 $ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-os-26k.ld" cargo run --release
+$ RUSTFLAGS="-C link-arg=-Tneotron-flash-0000.ld" cargo run --release
 ```
-
-TODO: Think of a better way of setting the memory limits for a particular OS build.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -19,43 +19,34 @@ This OS is a work in progress. We intend to support:
 
 ## Build instructions
 
-Your board will need an appropriate Neotron BIOS installed, and you need to
-have OpenOCD (or other programming tool) running for your particular board.
-You may also need to set the linker arguments so you link the binary to suit
-the memory available on your system.
+Your board will need an appropriate Neotron BIOS installed, and you need to have
+OpenOCD or some other programming tool running for your particular board. See
+your BIOS instructions for more details.
 
-### Build Instructions for the Neotron Pico (and other systems with Flash at `0x1000_0000`)
+We compile one version of Neotron OS, but we link it three times to produce
+three binaries:
 
-```
-$ git clone https://github.com/neotron-compute/Neotron-OS.git
-$ cd Neotron-OS
-$ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-flash-1000.ld" cargo build --release --target=thumbv6m-none-eabi
-```
-
-### Build Instructions for the STM32 (and other systems with Flash at `0x0800_0000`)
+* `flash0002` - is linked to run from address `0x0002_0000`
+* `flash1002` - is linked to run from address `0x1002_0000`
+* `flash0802` - is linked to run from address `0x0802_0000`
 
 ```
 $ git clone https://github.com/neotron-compute/Neotron-OS.git
 $ cd Neotron-OS
 $ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-flash-0800.ld" cargo build --release --target=thumbv6m-none-eabi
+$ cargo build --release
+$ ls ./target/thumbv6m-none-eabi/release/flash{10,08,00}02
+./target/thumbv6m-none-eabi/release/flash0002 ./target/thumbv6m-none-eabi/release/flash0802 ./target/thumbv6m-none-eabi/release/flash1002
 ```
 
-### Build Instructions for other systems (with Flash at `0x0000_0000`)
-
-```
-$ git clone https://github.com/neotron-compute/Neotron-OS.git
-$ cd Neotron-OS
-$ git submodule update --init
-$ RUSTFLAGS="-C link-arg=-Tneotron-flash-0000.ld" cargo run --release
-```
+Your BIOS should tell you which one you want and how to load it onto your system.
 
 ## Changelog
 
 ### Unreleased Changes ([Source](https://github.com/neotron-compute/Neotron-OS/tree/master))
 
 * Basic `println!` to the text buffer.
+* Re-arranged linker script setup
 
 ## Licence
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bin=flash1002=-Tneotron-flash-1000.ld");
+    println!("cargo:rustc-link-arg-bin=flash0802=-Tneotron-flash-0800.ld");
+    println!("cargo:rustc-link-arg-bin=flash0002=-Tneotron-flash-0000.ld");
+}

--- a/neotron-flash-0000.ld
+++ b/neotron-flash-0000.ld
@@ -21,15 +21,13 @@
 /* Provides information about the memory layout of the device */
 MEMORY
 {
-    /* The BIOS gets the first 128 KiB of Flash, leaving 1920 KiB for the OS */
-    FLASH (rx)  : ORIGIN = 0x10020000, LENGTH = 0x1E0000
+    /* The first 128 KiB is for the BIOS. We get the rest. */
+    FLASH (rx)  : ORIGIN = 0x00020000, LENGTH = 128K
     /*
-     * The RP2040 has 256 KiB of SRAM striped across four banks (for high
-     * performance), plus a fifth bank containing another 8 KiB of RAM. The
-     * BIOS is at the top of the high-performance RAM. We get the lower part.
+     * We get the bottom 4KB of RAM. Anything above that is for applications
+     * (up to wherever the BIOS tells us we can use.)
      */
-    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 0x3C000
-    /* The SDRAM holds the LCD framebuffers */
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 4K
 }
 
 /* # Entry point = what the BIOS calls to start the OS */

--- a/neotron-flash-0800.ld
+++ b/neotron-flash-0800.ld
@@ -21,14 +21,13 @@
 /* Provides information about the memory layout of the device */
 MEMORY
 {
-    /* The BIOS gets the first 512 KiB of Flash, leaving 512 KiB for the OS */
-    FLASH (rx)  : ORIGIN = 0x08080000, LENGTH = 512K
-    /* The BIOS gets the top 64 KiB of SRAM (including the Stack), leaving 256 KiB for the OS
-       (at 0x2000_0000 to 0x2003_FFFF). The RAM is actually split into three banks, but we can
-       largely ignore that.
-    */
-    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
-    /* The SDRAM holds the LCD framebuffers */
+    /* The first 128 KiB is for the BIOS. We get the rest. */
+    FLASH (rx)  : ORIGIN = 0x08020000, LENGTH = 128K
+    /*
+     * We get the bottom 4KB of RAM. Anything above that is for applications
+     * (up to wherever the BIOS tells us we can use.)
+     */
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 4K
 }
 
 /* # Entry point = what the BIOS calls to start the OS */

--- a/neotron-flash-1000.ld
+++ b/neotron-flash-1000.ld
@@ -21,10 +21,13 @@
 /* Provides information about the memory layout of the device */
 MEMORY
 {
-    /* The OS gets the top 128 KiB of Flash, leaving the first 128 KiB for the BIOS */
-    FLASH (rx)  : ORIGIN = 0x00020000, LENGTH = 128K
-    /* The BIOS gets the top 6 KiB of SRAM (including the Stack), leaving 26 KiB for the OS (at 0x2000_0000 to 0x2000_67FF) */
-    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 26K
+    /* The first 128 KiB is for the BIOS. We get the rest. */
+    FLASH (rx)  : ORIGIN = 0x10020000, LENGTH = 128K
+    /*
+     * We get the bottom 4KB of RAM. Anything above that is for applications
+     * (up to wherever the BIOS tells us we can use.)
+     */
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 4K
 }
 
 /* # Entry point = what the BIOS calls to start the OS */

--- a/src/bin/flash0002.rs
+++ b/src/bin/flash0002.rs
@@ -1,0 +1,17 @@
+//! Binary Neotron OS Image
+//!
+//! This is for Flash Addresses that start at `0x0002_0000`.
+//!
+//! Copyright (c) The Neotron Developers, 2022
+//!
+//! Licence: GPL v3 or higher (see ../LICENCE.md)
+
+#![no_std]
+#![no_main]
+
+/// This tells the BIOS how to start the OS. This must be the first four bytes
+/// of our portion of Flash.
+#[link_section = ".entry_point"]
+#[used]
+pub static ENTRY_POINT_ADDR: extern "C" fn(&'static neotron_common_bios::Api) -> ! =
+    neotron_os::main;

--- a/src/bin/flash0802.rs
+++ b/src/bin/flash0802.rs
@@ -1,0 +1,17 @@
+//! Binary Neotron OS Image
+//!
+//! This is for Flash Addresses that start at `0x0802_0000`.
+//!
+//! Copyright (c) The Neotron Developers, 2022
+//!
+//! Licence: GPL v3 or higher (see ../LICENCE.md)
+
+#![no_std]
+#![no_main]
+
+/// This tells the BIOS how to start the OS. This must be the first four bytes
+/// of our portion of Flash.
+#[link_section = ".entry_point"]
+#[used]
+pub static ENTRY_POINT_ADDR: extern "C" fn(&'static neotron_common_bios::Api) -> ! =
+    neotron_os::main;

--- a/src/bin/flash1002.rs
+++ b/src/bin/flash1002.rs
@@ -1,0 +1,17 @@
+//! Binary Neotron OS Image
+//!
+//! This is for Flash Addresses that start at `0x1002_0000`.
+//!
+//! Copyright (c) The Neotron Developers, 2022
+//!
+//! Licence: GPL v3 or higher (see ../LICENCE.md)
+
+#![no_std]
+#![no_main]
+
+/// This tells the BIOS how to start the OS. This must be the first four bytes
+/// of our portion of Flash.
+#[link_section = ".entry_point"]
+#[used]
+pub static ENTRY_POINT_ADDR: extern "C" fn(&'static neotron_common_bios::Api) -> ! =
+    neotron_os::main;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,11 @@
 //!
 //! This OS is intended to be loaded by a Neotron BIOS.
 //!
-//! Copyright (c) The Neotron Developers, 2020
+//! Copyright (c) The Neotron Developers, 2022
 //!
 //! Licence: GPL v3 or higher (see ../LICENCE.md)
 
 #![no_std]
-#![no_main]
 
 // Imports
 use core::fmt::Write;
@@ -17,12 +16,6 @@ use serde::{Deserialize, Serialize};
 // ===========================================================================
 // Global Variables
 // ===========================================================================
-
-/// This tells the BIOS how to start the OS. This must be the first four bytes
-/// of our portion of Flash.
-#[link_section = ".entry_point"]
-#[used]
-pub static ENTRY_POINT_ADDR: extern "C" fn(&'static bios::Api) -> ! = main;
 
 /// The OS version string
 const OS_VERSION: &str = concat!("Neotron OS, version ", env!("CARGO_PKG_VERSION"), "-2");
@@ -282,7 +275,7 @@ unsafe fn start_up_init() {
 
 /// This is the function the BIOS calls. This is because we store the address
 /// of this function in the ENTRY_POINT_ADDR variable.
-extern "C" fn main(api: &'static bios::Api) -> ! {
+pub extern "C" fn main(api: &'static bios::Api) -> ! {
     unsafe {
         start_up_init();
         API = Some(api);

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,7 +295,7 @@ extern "C" fn main(api: &'static bios::Api) -> ! {
         let mut width = 0;
         let mut height = 0;
         (api.video_memory_info_get)(&mut addr, &mut width, &mut height);
-        if addr != core::ptr::null_mut() {
+        if !addr.is_null() {
             let mut vga = VgaConsole {
                 addr,
                 width,


### PR DESCRIPTION
Neotron OS now only ever gets 4KiB of RAM at 0x2000_0000. It learns
about the rest from the BIOS. We always assume the BIOS is 128 KiB. If
it is larger, it has to split itself into two parts.