### PR TITLE
Fix thumb build on macOS.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,7 @@ fn main() {
         println!("cargo:rustc-env=OS_VERSION={}", env!("CARGO_PKG_VERSION"));
     }
 
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-lib=c");
+    if Ok("macos") == env::var("CARGO_CFG_TARGET_OS").as_deref() {
+        println!("cargo:rustc-link-lib=c");
+    }
 }


### PR DESCRIPTION
We need to include libc only when we are building neotron-os for macOS, not when we are building the build.rs file itself for macOS.