### PR TITLE
Colour screen fill command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,8 +8,11 @@ mkdir -p ${RELEASE_DIR}
 
 # Build the embedded binaries for each core type and each flash layout
 for TARGET_ARCH in thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi; do
+  echo "TARGET is ${TARGET_ARCH}"
   for BINARY in flash0002 flash0802 flash1002; do
-    # objcopy will do the build for us first
+    echo "BINARY is ${BINARY}"
+    cargo build --verbose --release --target=${TARGET_ARCH} --bin ${BINARY}
+    # objcopy would do the build for us first, but it doesn't have good build output
     cargo objcopy --verbose --release --target=${TARGET_ARCH} --bin ${BINARY} -- -O binary ${RELEASE_DIR}/${TARGET_ARCH}-${BINARY}-libneotron_os.bin
     # Keep the ELF file too (for debugging)
     cp ./target/${TARGET_ARCH}/release/${BINARY} ${RELEASE_DIR}/${TARGET_ARCH}-${BINARY}-libneotron_os.elf
@@ -17,5 +20,6 @@ for TARGET_ARCH in thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabi; do
 done
 
 # Build the host version
+echo "Building HOST"
 cargo build --verbose --lib --release --target=x86_64-unknown-linux-gnu
 cp ./target/x86_64-unknown-linux-gnu/release/libneotron_os.so ${RELEASE_DIR}/x86_64-unknown-linux-gnu-libneotron_os.so

--- a/src/commands/screen.rs
+++ b/src/commands/screen.rs
@@ -1,6 +1,8 @@
 //! Screen-related commands for Neotron OS
 
-use crate::{print, println, Ctx, API, VGA_CONSOLE};
+use neotron_common_bios::video::{Attr, TextBackgroundColour, TextForegroundColour};
+
+use crate::{println, Ctx, API, VGA_CONSOLE};
 
 pub static CLEAR_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
@@ -31,19 +33,39 @@ fn clear(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx:
 fn fill(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
     if let Some(ref mut console) = unsafe { &mut VGA_CONSOLE } {
         console.clear();
-    }
-    let api = API.get();
-    let mode = (api.video_get_mode)();
-    let (Some(width), Some(height)) = (mode.text_width(), mode.text_height()) else {
-        println!("Unable to get console size");
-        return;
-    };
-    // A range of printable ASCII compatible characters
-    let mut char_cycle = (' '..='~').cycle();
-    // Scroll two screen fulls
-    for _row in 0..height * 2 {
-        for _col in 0..width {
-            print!("{}", char_cycle.next().unwrap());
+        let api = API.get();
+        let mode = (api.video_get_mode)();
+        let (Some(width), Some(height)) = (mode.text_width(), mode.text_height()) else {
+            println!("Unable to get console size");
+            return;
+        };
+        // A range of printable ASCII compatible characters
+        let mut char_cycle = (b' '..=b'~').cycle();
+        let mut remaining = height * width;
+
+        // Scroll two screen fulls
+        'outer: for bg in (0..=7).cycle() {
+            let bg_colour = TextBackgroundColour::new(bg).unwrap();
+            for fg in 1..=15 {
+                if fg == bg {
+                    continue;
+                }
+                let fg_colour = TextForegroundColour::new(fg).unwrap();
+                remaining -= 1;
+                if remaining == 0 {
+                    break 'outer;
+                }
+                let attr = Attr::new(fg_colour, bg_colour, false);
+                let glyph = char_cycle.next().unwrap();
+                console.set_attr(attr);
+                console.write_bstr(&[glyph]);
+            }
         }
+        let attr = Attr::new(
+            TextForegroundColour::WHITE,
+            TextBackgroundColour::BLACK,
+            false,
+        );
+        console.set_attr(attr);
     }
 }


### PR DESCRIPTION
The `screen_fill` command writes colour characters to the screen.

Tested on the desktop BIOS.

![image](https://user-images.githubusercontent.com/959887/228947930-e0dcfa06-af10-4910-a0c8-d303e288c532.png)
