### PR TITLE
Add Nix flake based build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,127 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1684468982,
+        "narHash": "sha256-EoC1N5sFdmjuAP3UOkyQujSOT6EdcXTnRw8hPjJkEgc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "99de890b6ef4b4aab031582125b6056b792a4a30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1684432087,
+        "narHash": "sha256-3zFTOY/3+kN9x9Zdq6ixLmgV4ZcEd1aafq41v/OVUek=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7721e0d2c1845c24eafd5a016b9d349187c48097",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1684462813,
+        "narHash": "sha256-YFphDnxzXtLLExXjiR9bUVF4isI/MKiC4HMboh2ZSOc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e2ceeaa7f9334c5d732323b6fec363229da4f382",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+{
+  description = "Neotron OS";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+        rust-overlay.follows = "rust-overlay";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
+    let
+      # List of systems this flake.nix has been tested to work with
+      systems = [ "x86_64-linux" ];
+    in
+    flake-utils.lib.eachSystem systems
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
+            rust-overlay.overlays.default
+          ];
+          lib = pkgs.lib;
+          targets = [
+            "thumbv6m-none-eabi"
+            "thumbv7m-none-eabi"
+            "thumbv7em-none-eabi"
+          ];
+          toolchain = pkgs.rust-bin.stable.latest.default.override { inherit targets; };
+          craneLib = (crane.mkLib pkgs).overrideToolchain toolchain;
+
+          neotron-packages = builtins.listToAttrs (map
+            (tgt:
+              let arch = lib.head (builtins.split "-" tgt);
+              in {
+                name = "neotron-os-${arch}";
+                value = craneLib.buildPackage {
+                  pname = "neotron-os";
+                  nativeBuildInputs = [
+                    pkgs.gcc-arm-embedded
+                  ];
+                  doCheck = false;
+                  src = with pkgs.lib;
+                    let keep = suffix: path: type: hasSuffix suffix path;
+                    in
+                    cleanSourceWith {
+                      src = craneLib.path ./.;
+                      filter = path: type: any id (map (f: f path type) [
+                        craneLib.filterCargoSources
+                        (keep ".ld")
+                      ]);
+                    };
+                  cargoExtraArgs = "--target=${tgt}";
+                  installPhase = ''
+                    runHook preInstall
+                    mkdir -p $out/bin
+                  '' + toString (map
+                    (bin: ''
+                      cp target/${tgt}/release/${bin} $out/bin/${tgt}-${bin}-libneotron_os.elf
+                      arm-none-eabi-objcopy -O binary target/${tgt}/release/${bin} $out/bin/${tgt}-${bin}-libneotron_os.bin
+                    '') [ "flash0002" "flash0802" "flash1002" ]) + ''
+                    runHook postInstall
+                  '';
+                };
+              }
+            )
+            targets);
+        in
+        {
+          packages = neotron-packages;
+
+          devShell = pkgs.mkShell {
+            inputsFrom = builtins.attrValues self.packages.${system};
+          };
+        }
+      );
+}


### PR DESCRIPTION
`flake.nix` allows both building the project using the [Nix package manager](https://nixos.org/) and/or using a predefined environment for local development. `flake.lock` works similarly to `Cargo.lock`, locking the environment used to build the project.

The code probably won't make much sense to you if you're not familiar with Nix, but I've tested that this works, at least on x86_64-linux.