### PR TITLE
Support using the Neotron OS as a library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,5 @@ chrono = { version = "0.4", default-features = false }
 embedded-sdmmc = { version = "0.5", default-features = false }
 neotron-api = "0.1"
 
+[features]
+lib-mode = []

--- a/src/bin/flash0002.rs
+++ b/src/bin/flash0002.rs
@@ -13,4 +13,4 @@
 /// of our portion of Flash.
 #[link_section = ".entry_point"]
 #[used]
-pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::main;
+pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;

--- a/src/bin/flash0802.rs
+++ b/src/bin/flash0802.rs
@@ -13,4 +13,4 @@
 /// of our portion of Flash.
 #[link_section = ".entry_point"]
 #[used]
-pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::main;
+pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;

--- a/src/bin/flash1002.rs
+++ b/src/bin/flash1002.rs
@@ -13,4 +13,4 @@
 /// of our portion of Flash.
 #[link_section = ".entry_point"]
 #[used]
-pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::main;
+pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;

--- a/src/program.rs
+++ b/src/program.rs
@@ -177,7 +177,6 @@ impl TransientProgramArea {
             return Err(Error::BadAddress(start_addr));
         }
         println!("OK!");
-        drop(application_ram);
         let result = unsafe {
             let code: extern "C" fn(*const neotron_api::Api) -> i32 =
                 ::core::mem::transmute(start_addr as *const ());


### PR DESCRIPTION
In case you want to use it in a BIOS as a library, rather than compiling in separately.

The feature flag turns off variable initialisation (the start-up already did that), and turns off the panic handler (your binary should do that).