### PR TITLE
Update OS to use new common crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+* Switch to neotron-common-bios 0.9
+
 ## v0.4.0
 
 * The `load` command now takes ELF binaries, not raw binaries.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,10 +138,10 @@ dependencies = [
 [[package]]
 name = "neotron-common-bios"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4b43ef66a881b66110e2bafd11a8cd06613d0e99c52c9e8cdbc1195c61b94b"
+source = "git+https://github.com/neotron-compute/neotron-common-bios?branch=develop#e46b0efdf109faf85be5732e3e1eb4f688f7e26f"
 dependencies = [
  "chrono",
+ "neotron-ffi",
  "pc-keyboard",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,8 +137,9 @@ dependencies = [
 
 [[package]]
 name = "neotron-common-bios"
-version = "0.8.0"
-source = "git+https://github.com/neotron-compute/neotron-common-bios?branch=develop#e46b0efdf109faf85be5732e3e1eb4f688f7e26f"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab0dc15bdff1f816ff9f1173467ccb155cda9e9ccb3cb4853883eb393f9f3e2"
 dependencies = [
  "chrono",
  "neotron-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-neotron-common-bios = "0.8"
+neotron-common-bios = { git = "https://github.com/neotron-compute/neotron-common-bios", branch="develop" }
 pc-keyboard = "0.7"
 r0 = "1.0"
 postcard = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-neotron-common-bios = { git = "https://github.com/neotron-compute/neotron-common-bios", branch="develop" }
+neotron-common-bios = "0.9"
 pc-keyboard = "0.7"
 r0 = "1.0"
 postcard = "1.0"

--- a/src/commands/block.rs
+++ b/src/commands/block.rs
@@ -36,7 +36,7 @@ fn lsblk(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx:
 
     println!("Block Devices:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.block_dev_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.block_dev_get_info)(dev_idx) {
             let (bsize, bunits, dsize, dunits) =
                 match device_info.num_blocks * u64::from(device_info.block_size) {
                     x if x < (1024 * 1024 * 1024) => {
@@ -91,9 +91,9 @@ fn read_block(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], _
         dev_idx,
         bios::block_dev::BlockIdx(block_idx),
         1,
-        bios::ApiBuffer::new(&mut buffer),
+        bios::FfiBuffer::new(&mut buffer),
     ) {
-        bios::Result::Ok(_) => {
+        bios::ApiResult::Ok(_) => {
             // Carry on
             let mut count = 0;
             for chunk in buffer.chunks(32) {
@@ -105,7 +105,7 @@ fn read_block(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], _
                 println!();
             }
         }
-        bios::Result::Err(e) => {
+        bios::ApiResult::Err(e) => {
             println!("Failed to read: {:?}", e);
         }
     }

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -18,7 +18,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("Memory regions:");
     for region_idx in 0..=255u8 {
-        if let bios::Option::Some(region) = (api.memory_get_region)(region_idx) {
+        if let bios::FfiOption::Some(region) = (api.memory_get_region)(region_idx) {
             println!("  {}: {}", region_idx, region);
             found = true;
         }
@@ -31,7 +31,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("Serial Devices:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.serial_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.serial_get_info)(dev_idx) {
             println!(
                 "  {}: {} {:?}",
                 dev_idx, device_info.name, device_info.device_type
@@ -47,7 +47,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("Block Devices:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.block_dev_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.block_dev_get_info)(dev_idx) {
             println!(
                 "  {}: {} {:?} bs={} size={} MiB",
                 dev_idx,
@@ -67,7 +67,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("I2C Buses:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.i2c_bus_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.i2c_bus_get_info)(dev_idx) {
             println!("  {}: {:?}", dev_idx, device_info);
             found = true;
         }
@@ -80,7 +80,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("Neotron Bus Devices:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.bus_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.bus_get_info)(dev_idx) {
             println!("  {}: {:?}", dev_idx, device_info);
             found = true;
         }
@@ -93,7 +93,7 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 
     println!("Audio Mixers:");
     for dev_idx in 0..=255u8 {
-        if let bios::Option::Some(device_info) = (api.audio_mixer_channel_get_info)(dev_idx) {
+        if let bios::FfiOption::Some(device_info) = (api.audio_mixer_channel_get_info)(dev_idx) {
             println!("  {}: {:?}", dev_idx, device_info);
             found = true;
         }

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -16,7 +16,7 @@ fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], ctx:
     let api = API.get();
     loop {
         match (api.hid_get_event)() {
-            bios::Result::Ok(bios::Option::Some(bios::hid::HidEvent::KeyPress(code))) => {
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyPress(code))) => {
                 let pckb_ev = pc_keyboard::KeyEvent {
                     code,
                     state: pc_keyboard::KeyState::Down,
@@ -30,7 +30,7 @@ fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], ctx:
                     break;
                 }
             }
-            bios::Result::Ok(bios::Option::Some(bios::hid::HidEvent::KeyRelease(code))) => {
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyRelease(code))) => {
                 let pckb_ev = pc_keyboard::KeyEvent {
                     code,
                     state: pc_keyboard::KeyState::Up,
@@ -41,11 +41,13 @@ fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], ctx:
                     println!("Code={code:?} State=Up Decoded=None");
                 }
             }
-            bios::Result::Ok(bios::Option::Some(bios::hid::HidEvent::MouseInput(_ignore))) => {}
-            bios::Result::Ok(bios::Option::None) => {
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::MouseInput(
+                _ignore,
+            ))) => {}
+            bios::ApiResult::Ok(bios::FfiOption::None) => {
                 // Do nothing
             }
-            bios::Result::Err(e) => {
+            bios::ApiResult::Err(e) => {
                 println!("Failed to get HID events: {:?}", e);
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,11 +17,11 @@ impl Config {
     pub fn load() -> Result<Config, &'static str> {
         let api = API.get();
         let mut buffer = [0u8; 64];
-        match (api.configuration_get)(bios::ApiBuffer::new(&mut buffer)) {
-            bios::Result::Ok(n) => {
+        match (api.configuration_get)(bios::FfiBuffer::new(&mut buffer)) {
+            bios::ApiResult::Ok(n) => {
                 postcard::from_bytes(&buffer[0..n]).map_err(|_e| "Failed to parse config")
             }
-            bios::Result::Err(_e) => Err("Failed to load config"),
+            bios::ApiResult::Err(_e) => Err("Failed to load config"),
         }
     }
 
@@ -29,10 +29,12 @@ impl Config {
         let api = API.get();
         let mut buffer = [0u8; 64];
         let slice = postcard::to_slice(self, &mut buffer).map_err(|_e| "Failed to parse config")?;
-        match (api.configuration_set)(bios::ApiByteSlice::new(slice)) {
-            bios::Result::Ok(_) => Ok(()),
-            bios::Result::Err(bios::Error::Unimplemented) => Err("BIOS doesn't support this (yet)"),
-            bios::Result::Err(_) => Err("BIOS reported an error"),
+        match (api.configuration_set)(bios::FfiByteSlice::new(slice)) {
+            bios::ApiResult::Ok(_) => Ok(()),
+            bios::ApiResult::Err(bios::Error::Unimplemented) => {
+                Err("BIOS doesn't support this (yet)")
+            }
+            bios::ApiResult::Err(_) => Err("BIOS reported an error"),
         }
     }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -27,10 +27,10 @@ impl embedded_sdmmc::BlockDevice for BiosBlock {
             0,
             bios::block_dev::BlockIdx(u64::from(start_block_idx.0)),
             blocks.len() as u8,
-            bios::ApiBuffer::new(byte_slice),
+            bios::FfiBuffer::new(byte_slice),
         ) {
-            bios::Result::Ok(_) => Ok(()),
-            bios::Result::Err(e) => Err(e),
+            bios::ApiResult::Ok(_) => Ok(()),
+            bios::ApiResult::Err(e) => Err(e),
         }
     }
 
@@ -50,18 +50,18 @@ impl embedded_sdmmc::BlockDevice for BiosBlock {
             0,
             bios::block_dev::BlockIdx(u64::from(start_block_idx.0)),
             blocks.len() as u8,
-            bios::ApiByteSlice::new(byte_slice),
+            bios::FfiByteSlice::new(byte_slice),
         ) {
-            bios::Result::Ok(_) => Ok(()),
-            bios::Result::Err(e) => Err(e),
+            bios::ApiResult::Ok(_) => Ok(()),
+            bios::ApiResult::Err(e) => Err(e),
         }
     }
 
     fn num_blocks(&self) -> Result<embedded_sdmmc::BlockCount, Self::Error> {
         let api = API.get();
         match (api.block_dev_get_info)(0) {
-            bios::Option::Some(info) => Ok(embedded_sdmmc::BlockCount(info.num_blocks as u32)),
-            bios::Option::None => Err(bios::Error::InvalidDevice),
+            bios::FfiOption::Some(info) => Ok(embedded_sdmmc::BlockCount(info.num_blocks as u32)),
+            bios::FfiOption::None => Err(bios::Error::InvalidDevice),
         }
     }
 }


### PR DESCRIPTION
Use published version 0.9 of neotron-common-bios.

This brings in the neotron-ffi crate to describe the basic C-compatible types we share.