### PR TITLE
Add ANSI parser, and cursor support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "atomic-polyfill"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "neotron-common-bios"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab0dc15bdff1f816ff9f1173467ccb155cda9e9ccb3cb4853883eb393f9f3e2"
+checksum = "92fd2082f0e521c384d821cd7ac502ede5c7891cfaee3275653ecd31fac8aad4"
 dependencies = [
  "chrono",
  "neotron-ffi",
@@ -172,6 +178,7 @@ dependencies = [
  "postcard",
  "r0",
  "serde",
+ "vte",
 ]
 
 [[package]]
@@ -308,7 +315,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "git+https://github.com/neotron-compute/vte?branch=limit-osc-raw-size#3e04d4e0b2917213f8fdba61355aa1e1ac75bab0"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "git+https://github.com/neotron-compute/vte?branch=limit-osc-raw-size#3e04d4e0b2917213f8fdba61355aa1e1ac75bab0"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "git+https://github.com/neotron-compute/vte?branch=limit-osc-raw-size#3e04d4e0b2917213f8fdba61355aa1e1ac75bab0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-neotron-common-bios = "0.9"
+neotron-common-bios = "0.10"
 pc-keyboard = "0.7"
 r0 = "1.0"
 postcard = "1.0"
@@ -51,6 +51,7 @@ chrono = { version = "0.4", default-features = false }
 embedded-sdmmc = { version = "0.5", default-features = false }
 neotron-api = "0.1"
 neotron-loader = "0.1"
+vte = { git = "https://github.com/neotron-compute/vte", branch="limit-osc-raw-size" }
 
 [features]
 lib-mode = []

--- a/src/vgaconsole.rs
+++ b/src/vgaconsole.rs
@@ -5,13 +5,23 @@
 
 use neotron_common_bios::video::{Attr, TextBackgroundColour, TextForegroundColour};
 
-pub struct VgaConsole {
+struct ConsoleInner {
     addr: *mut u8,
     width: isize,
     height: isize,
     row: isize,
     col: isize,
     attr: Attr,
+    bright: bool,
+    reverse: bool,
+    cursor_wanted: bool,
+    cursor_depth: u8,
+    cursor_holder: Option<u8>,
+}
+
+pub struct VgaConsole {
+    inner: ConsoleInner,
+    parser: vte::Parser<16>,
 }
 
 impl VgaConsole {
@@ -24,13 +34,81 @@ impl VgaConsole {
 
     pub fn new(addr: *mut u8, width: isize, height: isize) -> VgaConsole {
         VgaConsole {
-            addr,
-            width,
-            height,
-            row: 0,
-            col: 0,
-            attr: Self::DEFAULT_ATTR,
+            inner: ConsoleInner {
+                addr,
+                width,
+                height,
+                row: 0,
+                col: 0,
+                attr: Self::DEFAULT_ATTR,
+                bright: false,
+                reverse: false,
+                cursor_wanted: false,
+                cursor_holder: None,
+                cursor_depth: 0,
+            },
+            parser: vte::Parser::new_with_size(),
         }
+    }
+
+    /// Clear the screen.
+    ///
+    /// Every character on the screen is replaced with an space (U+0020).
+    pub fn clear(&mut self) {
+        self.inner.cursor_disable();
+        self.inner.clear();
+        self.inner.cursor_enable();
+    }
+
+    /// Set the default attribute for any future text.
+    pub fn set_attr(&mut self, attr: Attr) {
+        self.inner.set_attr(attr);
+    }
+
+    /// Write a UTF-8 byte string to the console.
+    ///
+    /// Is parsed for ANSI codes, and Unicode is converted to Code Page 850 for
+    /// display on the VGA screen.
+    pub fn write_bstr(&mut self, bstr: &[u8]) {
+        self.inner.cursor_disable();
+        for b in bstr {
+            self.parser.advance(&mut self.inner, *b);
+        }
+        self.inner.cursor_enable();
+    }
+}
+
+impl ConsoleInner {
+    const DEFAULT_ATTR: Attr = Attr::new(
+        TextForegroundColour::LIGHT_GRAY,
+        TextBackgroundColour::BLACK,
+        false,
+    );
+
+    /// Replace the glyph at the current location with a cursor.
+    fn cursor_enable(&mut self) {
+        self.cursor_depth -= 1;
+        if self.cursor_depth == 0 && self.cursor_wanted && self.cursor_holder.is_none() {
+            // Remember what was where our cursor is (unless the cursor is off-screen, when we make something up)
+            if self.row >= 0 && self.row < self.height && self.col >= 0 && self.col < self.width {
+                let value = self.read();
+                self.write_at(self.row, self.col, b'_', true);
+                self.cursor_holder = Some(value);
+            } else {
+                self.cursor_holder = Some(b' ');
+            }
+        }
+    }
+
+    /// Replace the cursor at the current location with its previous contents.
+    fn cursor_disable(&mut self) {
+        if let Some(glyph) = self.cursor_holder.take() {
+            if self.row >= 0 && self.row < self.height && self.col >= 0 && self.col < self.width {
+                // cursor was on-screen, so restore it
+                self.write(glyph);
+            }
+        }
+        self.cursor_depth += 1;
     }
 
     fn move_char_right(&mut self) {
@@ -41,9 +119,33 @@ impl VgaConsole {
         self.row += 1;
     }
 
-    fn reset_cursor(&mut self) {
-        self.row = 0;
-        self.col = 0;
+    fn move_cursor_relative(&mut self, rows: isize, cols: isize) {
+        self.row += rows;
+        self.col += cols;
+        if self.row < 0 {
+            self.row = 0;
+        }
+        if self.col < 0 {
+            self.col = 0;
+        }
+        if self.row >= self.width {
+            self.row = self.width - 1;
+        }
+        if self.col >= self.height {
+            self.col = self.height - 1;
+        }
+    }
+
+    fn move_cursor_absolute(&mut self, rows: isize, cols: isize) {
+        // move it
+        self.row = rows;
+        self.col = cols;
+        // clamp it
+        self.move_cursor_relative(0, 0);
+    }
+
+    fn home(&mut self) {
+        self.move_cursor_absolute(0, 0);
     }
 
     fn scroll_as_required(&mut self) {
@@ -58,63 +160,80 @@ impl VgaConsole {
         }
     }
 
-    pub fn clear(&mut self) {
+    fn clear(&mut self) {
         for row in 0..self.height {
             for col in 0..self.width {
-                self.write_at(row, col, b' ');
+                self.write_at(row, col, b' ', false);
             }
         }
-        self.reset_cursor();
-    }
-
-    pub fn write_bstr(&mut self, bstr: &[u8]) {
-        for b in bstr {
-            self.scroll_as_required();
-            match b {
-                0x08 => {
-                    // This is a backspace, so we go back one character (if we
-                    // can). We expect the caller to provide "\u{0008} \u{0008}"
-                    // to actually erase the char then move the cursor over it.
-                    if self.col > 0 {
-                        self.col -= 1;
-                    }
-                }
-                b'\r' => {
-                    self.col = 0;
-                }
-                b'\n' => {
-                    self.col = 0;
-                    self.move_char_down();
-                }
-                _ => {
-                    self.write(*b);
-                    self.move_char_right();
-                }
-            }
-        }
+        self.home();
     }
 
     /// Set the default attribute for any future text.
-    pub fn set_attr(&mut self, attr: Attr) {
+    fn set_attr(&mut self, attr: Attr) {
         self.attr = attr;
     }
 
-    /// Put a glyph at the next position on the screen.
+    /// Put a glyph at the current position on the screen.
+    ///
+    /// Don't do this if the cursor is enabled.
     fn write(&mut self, glyph: u8) {
-        self.write_at(self.row, self.col, glyph);
+        self.write_at(self.row, self.col, glyph, false);
     }
 
     /// Put a glyph at a given position on the screen.
-    fn write_at(&mut self, row: isize, col: isize, glyph: u8) {
+    ///
+    /// Don't do this if the cursor is enabled.
+    fn write_at(&mut self, row: isize, col: isize, glyph: u8, is_cursor: bool) {
         assert!(row < self.height, "{} >= {}?", row, self.height);
         assert!(col < self.width, "{} => {}?", col, self.width);
+        if !crate::IS_PANIC.load(core::sync::atomic::Ordering::Relaxed) && !is_cursor {
+            assert!(self.cursor_holder.is_none());
+        }
+
         let offset = ((row * self.width) + col) * 2;
         unsafe { core::ptr::write_volatile(self.addr.offset(offset), glyph) };
-        unsafe { core::ptr::write_volatile(self.addr.offset(offset + 1), self.attr.as_u8()) };
+        let attr = if self.reverse {
+            let new_fg = self.attr.bg().as_u8();
+            let new_bg = self.attr.fg().as_u8();
+            Attr::new(
+                unsafe { TextForegroundColour::new_unchecked(new_fg) },
+                unsafe { TextBackgroundColour::new_unchecked(new_bg & 0x07) },
+                false,
+            )
+        } else {
+            self.attr
+        };
+
+        unsafe { core::ptr::write_volatile(self.addr.offset(offset + 1), attr.as_u8()) };
     }
 
+    /// Read a glyph at the current position
+    ///
+    /// Don't do this if the cursor is enabled.
+    fn read(&mut self) -> u8 {
+        self.read_at(self.row, self.col)
+    }
+
+    /// Read a glyph at the given position
+    ///
+    /// Don't do this if the cursor is enabled.
+    fn read_at(&mut self, row: isize, col: isize) -> u8 {
+        assert!(row < self.height, "{} >= {}?", row, self.height);
+        assert!(col < self.width, "{} => {}?", col, self.width);
+        if !crate::IS_PANIC.load(core::sync::atomic::Ordering::Relaxed) {
+            assert!(self.cursor_holder.is_none());
+        }
+        let offset = ((row * self.width) + col) * 2;
+        unsafe { core::ptr::read_volatile(self.addr.offset(offset)) }
+    }
+
+    /// Move everyone on screen up one line, losing the top line.
+    ///
+    /// The bottom line will be all space characters.
     fn scroll_page(&mut self) {
         let row_len_bytes = self.width * 2;
+        self.cursor_disable();
         unsafe {
             // Scroll rows[1..=height-1] to become rows[0..=height-2].
             core::ptr::copy(
@@ -122,10 +241,11 @@ impl VgaConsole {
                 self.addr,
                 (row_len_bytes * (self.height - 1)) as usize,
             );
-            // Blank the bottom line of the screen (rows[height-1]).
-            for col in 0..self.width {
-                self.write_at(self.height - 1, col, b' ');
-            }
+        }
+        self.cursor_enable();
+        // Blank the bottom line of the screen (rows[height-1]).
+        for col in 0..self.width {
+            self.write_at(self.height - 1, col, b' ', false);
         }
     }
 
@@ -273,31 +393,284 @@ impl VgaConsole {
 }
 
 impl core::fmt::Write for VgaConsole {
+    /// Write a UTF-8 string slice to the console.
+    ///
+    /// Is parsed for ANSI codes, and Unicode is converted to Code Page 850 for
+    /// display on the VGA screen.
     fn write_str(&mut self, data: &str) -> core::fmt::Result {
-        for ch in data.chars() {
-            self.scroll_as_required();
-            match ch {
-                '\u{0008}' => {
-                    // This is a backspace, so we go back one character (if we
-                    // can). We expect the caller to provide "\u{0008} \u{0008}"
-                    // to actually erase the char then move the cursor over it.
-                    if self.col > 0 {
-                        self.col -= 1;
-                    }
-                }
-                '\r' => {
-                    self.col = 0;
-                }
-                '\n' => {
-                    self.col = 0;
-                    self.move_char_down();
-                }
-                _ => {
-                    self.write(Self::map_char_to_glyph(ch));
-                    self.move_char_right();
+        self.inner.cursor_disable();
+        assert!(self.inner.cursor_holder.is_none());
+        for b in data.bytes() {
+            self.parser.advance(&mut self.inner, b);
+        }
+        self.inner.cursor_enable();
+        Ok(())
+    }
+}
+
+impl vte::Perform for ConsoleInner {
+    /// Draw a character to the screen and update states.
+    fn print(&mut self, ch: char) {
+        self.scroll_as_required();
+        self.write(Self::map_char_to_glyph(ch));
+        self.move_char_right();
+    }
+
+    /// Execute a C0 or C1 control function.
+    fn execute(&mut self, byte: u8) {
+        self.scroll_as_required();
+        match byte {
+            0x08 => {
+                // This is a backspace, so we go back one character (if we
+                // can). We expect the caller to provide "\u{0008} \u{0008}"
+                // to actually erase the char then move the cursor over it.
+                if self.col > 0 {
+                    self.col -= 1;
                 }
             }
+            b'\r' => {
+                self.col = 0;
+            }
+            b'\n' => {
+                self.col = 0;
+                self.move_char_down();
+            }
+            _ => {
+                // ignore unknown C0 or C1 control code
+            }
         }
-        Ok(())
+    }
+
+    /// A final character has arrived for a CSI sequence
+    ///
+    /// The `ignore` flag indicates that either more than two intermediates arrived
+    /// or the number of parameters exceeded the maximum supported length,
+    /// and subsequent characters were ignored.
+    fn csi_dispatch(
+        &mut self,
+        params: &vte::Params,
+        intermediates: &[u8],
+        _ignore: bool,
+        action: char,
+    ) {
+        // Just in case you want a single parameter, here it is
+        let mut first = params
+            .iter()
+            .next()
+            .and_then(|s| s.first())
+            .unwrap_or(&1)
+            .clone() as isize;
+        let mut second = params
+            .iter()
+            .skip(1)
+            .next()
+            .and_then(|s| s.first())
+            .unwrap_or(&1)
+            .clone() as isize;
+
+        match action {
+            'm' => {
+                // Select Graphic Rendition
+                for p in params.iter() {
+                    let Some(p) = p.first() else {
+                        // Can't handle sub-params, i.e. params with more than one value
+                        return;
+                    };
+                    match *p {
+                        0 => {
+                            // Reset, or normal
+                            self.attr = Self::DEFAULT_ATTR;
+                            self.bright = false;
+                            self.reverse = false;
+                        }
+                        1 => {
+                            // Bold intensity
+                            self.bright = true;
+                        }
+                        7 => {
+                            // Reverse video
+                            self.reverse = true;
+                        }
+                        22 => {
+                            // Normal intensity
+                            self.bright = false;
+                        }
+                        // Foreground
+                        30 => {
+                            self.attr.set_fg(TextForegroundColour::BLACK);
+                        }
+                        31 => {
+                            self.attr.set_fg(TextForegroundColour::RED);
+                        }
+                        32 => {
+                            self.attr.set_fg(TextForegroundColour::GREEN);
+                        }
+                        33 => {
+                            self.attr.set_fg(TextForegroundColour::BROWN);
+                        }
+                        34 => {
+                            self.attr.set_fg(TextForegroundColour::BLUE);
+                        }
+                        35 => {
+                            self.attr.set_fg(TextForegroundColour::MAGENTA);
+                        }
+                        36 => {
+                            self.attr.set_fg(TextForegroundColour::CYAN);
+                        }
+                        37 | 39 => {
+                            self.attr.set_fg(TextForegroundColour::LIGHT_GRAY);
+                        }
+                        // Background
+                        40 => {
+                            self.attr.set_bg(TextBackgroundColour::BLACK);
+                        }
+                        41 => {
+                            self.attr.set_bg(TextBackgroundColour::RED);
+                        }
+                        42 => {
+                            self.attr.set_bg(TextBackgroundColour::GREEN);
+                        }
+                        43 => {
+                            self.attr.set_bg(TextBackgroundColour::BROWN);
+                        }
+                        44 => {
+                            self.attr.set_bg(TextBackgroundColour::BLUE);
+                        }
+                        45 => {
+                            self.attr.set_bg(TextBackgroundColour::MAGENTA);
+                        }
+                        46 => {
+                            self.attr.set_bg(TextBackgroundColour::CYAN);
+                        }
+                        47 | 49 => {
+                            self.attr.set_bg(TextBackgroundColour::LIGHT_GRAY);
+                        }
+                        _ => {
+                            // Ignore unknown code
+                        }
+                    }
+                }
+                // Now check if we're bright, and make it brighter. We do this
+                // last, because they might set the colour first and set the
+                // bright bit afterwards.
+                if self.bright {
+                    match self.attr.fg() {
+                        TextForegroundColour::BLACK => {
+                            self.attr.set_fg(TextForegroundColour::DARK_GRAY);
+                        }
+                        TextForegroundColour::RED => {
+                            self.attr.set_fg(TextForegroundColour::LIGHT_RED);
+                        }
+                        TextForegroundColour::GREEN => {
+                            self.attr.set_fg(TextForegroundColour::LIGHT_GREEN);
+                        }
+                        TextForegroundColour::BROWN => {
+                            self.attr.set_fg(TextForegroundColour::YELLOW);
+                        }
+                        TextForegroundColour::BLUE => {
+                            self.attr.set_fg(TextForegroundColour::LIGHT_BLUE);
+                        }
+                        TextForegroundColour::MAGENTA => {
+                            self.attr.set_fg(TextForegroundColour::PINK);
+                        }
+                        TextForegroundColour::CYAN => {
+                            self.attr.set_fg(TextForegroundColour::LIGHT_CYAN);
+                        }
+                        TextForegroundColour::LIGHT_GRAY => {
+                            self.attr.set_fg(TextForegroundColour::WHITE);
+                        }
+                        _ => {
+                            // Do nothing
+                        }
+                    }
+                }
+            }
+            'A' => {
+                // Cursor Up
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_relative(-first, 0);
+            }
+            'B' => {
+                // Cursor Down
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_relative(first, 0);
+            }
+            'C' => {
+                // Cursor Forward
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_relative(0, first);
+            }
+            'D' => {
+                // Cursor Back
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_relative(0, -first);
+            }
+            'E' => {
+                // Cursor next line
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_absolute(self.row + first, 0);
+            }
+            'F' => {
+                // Cursor previous line
+                if first == 0 {
+                    first = 1;
+                }
+                self.move_cursor_absolute(self.row - first, 0);
+            }
+            'G' => {
+                // Cursor horizontal absolute
+                if first == 0 {
+                    first = 1;
+                }
+                // We are zero-indexed, ANSI is 1-indexed
+                self.move_cursor_absolute(first - 1, 0);
+            }
+            'H' | 'f' => {
+                // Cursor Position (or Horizontal Vertical Position)
+                if first == 0 {
+                    first = 1;
+                }
+                if second == 0 {
+                    second = 1;
+                }
+                // We are zero-indexed, ANSI is 1-indexed
+                self.move_cursor_absolute(first - 1, second - 1);
+            }
+            'J' => {
+                // Erase in Display - todo
+            }
+            'K' => {
+                // Erase in line - todo
+            }
+            'n' if first == 6 => {
+                // Device Status Report - todo.
+                //
+                // We should send "\u{001b}[<rows>;<cols>R" where <rows> and
+                // <cols> are integers for 1-indexed rows and columns
+                // respectively. But for that we need an input buffer to put bytes into.
+            }
+            'h' if intermediates.first().cloned() == Some(b'?') => {
+                // DEC special code for Cursor On. It'll be activated whenever
+                // we finish what we're printing.
+                self.cursor_wanted = true;
+            }
+            'l' if intermediates.first().cloned() == Some(b'?') => {
+                // DEC special code for Cursor Off.
+                self.cursor_wanted = false;
+            }
+            _ => {
+                // Unknown code - ignore it
+            }
+        }
     }
 }


### PR DESCRIPTION
phew.

Like the Monotron, we cheat with the cursor. Instead of making the BIOS support a hardware cursor, we fake it in software.

1. To enable the cursor, cache the glyph currently at the cursor position and replace it with a `_`
2. To disable the cursor, put the cached value back
3. Ensure you temporarily disable the cursor anytime you write to the screen, or really do anything with the screen
4. Realise you need to *recursively* enable and disable the cursor, because writing to the screen now goes through the ANSI state machine and that may then emit a second, recursive, write to the screen. Oof.