### PR TITLE
Adds standard-input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added ANSI decoder for colour changes (SGI) and cursor position support
 * Added 'standard input' support for applications
 * Use new compare-and-swap BIOS API to implement mutexes, instead of `static mut`
+* OS now requires 256K Flash space
 
 ## v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased changes
 
-* Switch to neotron-common-bios 0.9
+* Switch to neotron-common-bios 0.11
+* Added "Shutdown" command
+* Added ANSI decoder for colour changes (SGI) and cursor position support
+* Added 'standard input' support for applications
+* Use new compare-and-swap BIOS API to implement mutexes, instead of `static mut`
 
 ## v0.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,8 +149,9 @@ dependencies = [
 
 [[package]]
 name = "neotron-common-bios"
-version = "0.11.0-alpha"
-source = "git+https://github.com/neotron-compute/neotron-common-bios?branch=extra-functions#ebb78a501249ae0b444c95779284f43e8b2d8a26"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adad98cd2c761f72321c516359f53b8e0cd56637ee6332e7d8628d8144cad3a"
 dependencies = [
  "chrono",
  "neotron-ffi",
@@ -189,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -204,9 +205,9 @@ checksum = "ed089a1fbffe3337a1a345501c981f1eb1e47e69de5a40e852433e12953c3174"
 
 [[package]]
 name = "postcard"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa512cd0d087cc9f99ad30a1bf64795b67871edbead083ffc3a4dfafa59aa00"
+checksum = "c9ee729232311d3cd113749948b689627618133b1c5012b77342c1950b25eaeb"
 dependencies = [
  "cobs",
  "heapless",
@@ -248,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -260,18 +261,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -295,9 +296,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,8 @@ dependencies = [
 
 [[package]]
 name = "neotron-common-bios"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92fd2082f0e521c384d821cd7ac502ede5c7891cfaee3275653ecd31fac8aad4"
+version = "0.11.0-alpha"
+source = "git+https://github.com/neotron-compute/neotron-common-bios?branch=extra-functions#ebb78a501249ae0b444c95779284f43e8b2d8a26"
 dependencies = [
  "chrono",
  "neotron-ffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ version = "0.4.0"
 dependencies = [
  "chrono",
  "embedded-sdmmc",
+ "heapless",
  "menu",
  "neotron-api",
  "neotron-common-bios",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-neotron-common-bios = "0.10"
+neotron-common-bios = { version = "0.11.0-alpha", git = "https://github.com/neotron-compute/neotron-common-bios", branch = "extra-functions" }
 pc-keyboard = "0.7"
 r0 = "1.0"
 heapless = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ panic = "abort"
 panic = "abort"
 
 [dependencies]
-neotron-common-bios = { version = "0.11.0-alpha", git = "https://github.com/neotron-compute/neotron-common-bios", branch = "extra-functions" }
+neotron-common-bios = "0.11"
 pc-keyboard = "0.7"
 r0 = "1.0"
 heapless = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ panic = "abort"
 neotron-common-bios = "0.10"
 pc-keyboard = "0.7"
 r0 = "1.0"
+heapless = "0.7"
 postcard = "1.0"
 serde = { version = "1.0", default-features = false }
 menu = "0.3"

--- a/neotron-flash-0002.ld
+++ b/neotron-flash-0002.ld
@@ -22,7 +22,7 @@
 MEMORY
 {
     /* The first 128 KiB is for the BIOS. We get the rest. */
-    FLASH (rx)  : ORIGIN = 0x00020000, LENGTH = 128K
+    FLASH (rx)  : ORIGIN = 0x00020000, LENGTH = 256K
     /*
      * We get the bottom 4KB of RAM. Anything above that is for applications
      * (up to wherever the BIOS tells us we can use.)

--- a/neotron-flash-0802.ld
+++ b/neotron-flash-0802.ld
@@ -22,7 +22,7 @@
 MEMORY
 {
     /* The first 128 KiB is for the BIOS. We get the rest. */
-    FLASH (rx)  : ORIGIN = 0x08020000, LENGTH = 128K
+    FLASH (rx)  : ORIGIN = 0x08020000, LENGTH = 256K
     /*
      * We get the bottom 4KB of RAM. Anything above that is for applications
      * (up to wherever the BIOS tells us we can use.)

--- a/neotron-flash-1002.ld
+++ b/neotron-flash-1002.ld
@@ -22,7 +22,7 @@
 MEMORY
 {
     /* The first 128 KiB is for the BIOS. We get the rest. */
-    FLASH (rx)  : ORIGIN = 0x10020000, LENGTH = 128K
+    FLASH (rx)  : ORIGIN = 0x10020000, LENGTH = 256K
 
     /*
      * The RAM reserved for the OS. Above this is the Transient Program Area.

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -11,6 +11,18 @@ pub static LSHW_ITEM: menu::Item<Ctx> = menu::Item {
     help: Some("List all the BIOS hardware"),
 };
 
+pub static SHUTDOWN_ITEM: menu::Item<Ctx> = menu::Item {
+    item_type: menu::ItemType::Callback {
+        function: shutdown,
+        parameters: &[
+            menu::Parameter::Named { parameter_name: "reboot", help: Some("Reboot after shutting down") },
+            menu::Parameter::Named { parameter_name: "bootloader", help: Some("Reboot into the bootloader after shutting down") }
+        ],
+    },
+    command: "shutdown",
+    help: Some("Shutdown the system"),
+};
+
 /// Called when the "lshw" command is executed.
 fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
     let api = API.get();
@@ -102,5 +114,21 @@ fn lshw(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
     }
     if !found {
         osprintln!("  None");
+    }
+}
+
+/// Called when the "shutdown" command is executed.
+fn shutdown(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx: &mut Ctx) {
+    let api = API.get();
+
+    if let Ok(Some(_)) = menu::argument_finder(item, args, "reboot") {
+        osprintln!("Rebooting...");
+        (api.power_control)(bios::PowerMode::Reset);
+    } else if let Ok(Some(_)) = menu::argument_finder(item, args, "bootloader") {
+        osprintln!("Rebooting into bootloader...");
+        (api.power_control)(bios::PowerMode::Bootloader);
+    } else {
+        osprintln!("Shutting down...");
+        (api.power_control)(bios::PowerMode::Off);
     }
 }

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -15,8 +15,14 @@ pub static SHUTDOWN_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
         function: shutdown,
         parameters: &[
-            menu::Parameter::Named { parameter_name: "reboot", help: Some("Reboot after shutting down") },
-            menu::Parameter::Named { parameter_name: "bootloader", help: Some("Reboot into the bootloader after shutting down") }
+            menu::Parameter::Named {
+                parameter_name: "reboot",
+                help: Some("Reboot after shutting down"),
+            },
+            menu::Parameter::Named {
+                parameter_name: "bootloader",
+                help: Some("Reboot into the bootloader after shutting down"),
+            },
         ],
     },
     command: "shutdown",

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -1,6 +1,6 @@
 //! Input related commands for Neotron OS
 
-use crate::{bios, osprintln, Ctx, API};
+use crate::{osprintln, Ctx};
 
 pub static KBTEST_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
@@ -12,43 +12,15 @@ pub static KBTEST_ITEM: menu::Item<Ctx> = menu::Item {
 };
 
 /// Called when the "kbtest" command is executed.
-fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], ctx: &mut Ctx) {
-    let api = API.get();
+fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
+    osprintln!("Press ESC to quit");
     loop {
-        match (api.hid_get_event)() {
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyPress(code))) => {
-                let pckb_ev = pc_keyboard::KeyEvent {
-                    code,
-                    state: pc_keyboard::KeyState::Down,
-                };
-                if let Some(ev) = ctx.keyboard.process_keyevent(pckb_ev) {
-                    osprintln!("Code={code:?} State=Down Decoded={ev:?}");
-                } else {
-                    osprintln!("Code={code:?} State=Down Decoded=None");
-                }
-                if code == pc_keyboard::KeyCode::Escape {
-                    break;
-                }
-            }
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyRelease(code))) => {
-                let pckb_ev = pc_keyboard::KeyEvent {
-                    code,
-                    state: pc_keyboard::KeyState::Up,
-                };
-                if let Some(ev) = ctx.keyboard.process_keyevent(pckb_ev) {
-                    osprintln!("Code={code:?} State=Up Decoded={ev:?}");
-                } else {
-                    osprintln!("Code={code:?} State=Up Decoded=None");
-                }
-            }
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::MouseInput(
-                _ignore,
-            ))) => {}
-            bios::ApiResult::Ok(bios::FfiOption::None) => {
-                // Do nothing
-            }
-            bios::ApiResult::Err(e) => {
-                osprintln!("Failed to get HID events: {:?}", e);
+        if let Some(ev) = unsafe { crate::STD_INPUT.get_raw() } {
+            osprintln!("Event: {ev:?}");
+            if ev == pc_keyboard::DecodedKey::RawKey(pc_keyboard::KeyCode::Escape)
+                || ev == pc_keyboard::DecodedKey::Unicode('\u{001b}')
+            {
+                break;
             }
         }
     }

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -13,15 +13,32 @@ pub static KBTEST_ITEM: menu::Item<Ctx> = menu::Item {
 
 /// Called when the "kbtest" command is executed.
 fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
-    osprintln!("Press ESC to quit");
-    loop {
+    osprintln!("Press Ctrl-X to quit");
+    const CTRL_X: u8 = 0x18;
+    'outer: loop {
         if let Some(ev) = crate::STD_INPUT.lock().get_raw() {
             osprintln!("Event: {ev:?}");
-            if ev == pc_keyboard::DecodedKey::RawKey(pc_keyboard::KeyCode::Escape)
-                || ev == pc_keyboard::DecodedKey::Unicode('\u{001b}')
-            {
-                break;
+            if ev == pc_keyboard::DecodedKey::Unicode(CTRL_X as char) {
+                break 'outer;
+            }
+        }
+        let mut buffer = [0u8; 8];
+        let count = if let Some(serial) = crate::SERIAL_CONSOLE.lock().as_mut() {
+            serial
+                .read_data(&mut buffer)
+                .ok()
+                .and_then(|n| if n == 0 { None } else { Some(n) })
+        } else {
+            None
+        };
+        if let Some(count) = count {
+            osprintln!("Serial RX: {:x?}", &buffer[0..count]);
+            for b in &buffer[0..count] {
+                if *b == CTRL_X {
+                    break 'outer;
+                }
             }
         }
     }
+    osprintln!("Finished.");
 }

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -15,7 +15,7 @@ pub static KBTEST_ITEM: menu::Item<Ctx> = menu::Item {
 fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
     osprintln!("Press ESC to quit");
     loop {
-        if let Some(ev) = unsafe { crate::STD_INPUT.get_raw() } {
+        if let Some(ev) = crate::STD_INPUT.lock().get_raw() {
             osprintln!("Event: {ev:?}");
             if ev == pc_keyboard::DecodedKey::RawKey(pc_keyboard::KeyCode::Escape)
                 || ev == pc_keyboard::DecodedKey::Unicode('\u{001b}')

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
         &screen::FILL_ITEM,
         &screen::MANDEL_ITEM,
         &input::KBTEST_ITEM,
+        &hardware::SHUTDOWN_ITEM,
     ],
     entry: None,
     exit: None,

--- a/src/commands/screen.rs
+++ b/src/commands/screen.rs
@@ -42,14 +42,16 @@ pub static MANDEL_ITEM: menu::Item<Ctx> = menu::Item {
 
 /// Called when the "clear" command is executed.
 fn clear(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
-    if let Some(ref mut console) = unsafe { &mut VGA_CONSOLE } {
-        console.clear();
+    let mut guard = VGA_CONSOLE.try_lock().unwrap();
+    if let Some(vga_console) = guard.as_mut() {
+        vga_console.clear();
     }
 }
 
 /// Called when the "fill" command is executed.
 fn fill(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
-    if let Some(ref mut console) = unsafe { &mut VGA_CONSOLE } {
+    let mut guard = VGA_CONSOLE.try_lock().unwrap();
+    if let Some(console) = guard.as_mut() {
         console.clear();
         let api = API.get();
         let mode = (api.video_get_mode)();
@@ -91,7 +93,8 @@ fn fill(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: 
 /// Called when the "bench" command is executed.
 fn bench(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
     const NUM_CHARS: u64 = 1_000_000;
-    if let Some(ref mut console) = unsafe { &mut VGA_CONSOLE } {
+    let mut guard = VGA_CONSOLE.try_lock().unwrap();
+    if let Some(console) = guard.as_mut() {
         let api = API.get();
         let start = (api.time_ticks_get)();
         console.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,121 @@ static mut SERIAL_CONSOLE: Option<SerialConsole> = None;
 /// If so, don't panic if a serial write fails.
 static IS_PANIC: AtomicBool = AtomicBool::new(false);
 
+/// Our keyboard controller
+static mut STD_INPUT: StdInput = StdInput::new();
+
+struct StdInput {
+    keyboard: pc_keyboard::EventDecoder<pc_keyboard::layouts::AnyLayout>,
+    buffer: heapless::spsc::Queue<u8, 16>,
+}
+
+impl StdInput {
+    const fn new() -> StdInput {
+        StdInput {
+            keyboard: pc_keyboard::EventDecoder::new(
+                pc_keyboard::layouts::AnyLayout::Uk105Key(pc_keyboard::layouts::Uk105Key),
+                pc_keyboard::HandleControl::MapLettersToUnicode,
+            ),
+            buffer: heapless::spsc::Queue::new(),
+        }
+    }
+
+    fn get_buffered_data(&mut self, buffer: &mut [u8]) -> usize {
+        // If there is some data, get it.
+        let mut count = 0;
+        for slot in buffer.iter_mut() {
+            if let Some(n) = self.buffer.dequeue() {
+                *slot = n;
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Gets a raw event from the keyboard
+    fn get_raw(&mut self) -> Option<pc_keyboard::DecodedKey> {
+        let api = API.get();
+        match (api.hid_get_event)() {
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyPress(code))) => {
+                let pckb_ev = pc_keyboard::KeyEvent {
+                    code,
+                    state: pc_keyboard::KeyState::Down,
+                };
+                self.keyboard.process_keyevent(pckb_ev)
+            }
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyRelease(code))) => {
+                let pckb_ev = pc_keyboard::KeyEvent {
+                    code,
+                    state: pc_keyboard::KeyState::Up,
+                };
+                self.keyboard.process_keyevent(pckb_ev)
+            }
+            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::MouseInput(
+                _ignore,
+            ))) => None,
+            bios::ApiResult::Ok(bios::FfiOption::None) => {
+                // Do nothing
+                None
+            }
+            bios::ApiResult::Err(_e) => None,
+        }
+    }
+
+    /// Gets some input bytes, as UTF-8.
+    ///
+    /// The data you get might be cut in the middle of a UTF-8 character.
+    fn get_data(&mut self, buffer: &mut [u8]) -> usize {
+        let count = self.get_buffered_data(buffer);
+        if buffer.len() == 0 || count > 0 {
+            return count;
+        }
+
+        // Nothing buffered - ask the keyboard for something
+        let decoded_key = self.get_raw();
+
+        match decoded_key {
+            Some(pc_keyboard::DecodedKey::Unicode(mut ch)) => {
+                if ch == '\n' {
+                    ch = '\r';
+                }
+                let mut buffer = [0u8; 6];
+                let s = ch.encode_utf8(&mut buffer);
+                for b in s.as_bytes() {
+                    // This will always fit
+                    self.buffer.enqueue(*b).unwrap();
+                }
+            }
+            Some(pc_keyboard::DecodedKey::RawKey(pc_keyboard::KeyCode::ArrowRight)) => {
+                // Load the ANSI sequence for a right arrow
+                for b in b"\x1b[0;77b" {
+                    // This will always fit
+                    self.buffer.enqueue(*b).unwrap();
+                }
+            }
+            _ => {
+                // Drop anything else
+            }
+        }
+
+        // if let Some((uart_dev, _serial_conf)) = menu.context.config.get_serial_console() {
+        //     while !self.buffer.is_full() {
+        //         let mut buffer = [0u8];
+        //         let wrapper = neotron_common_bios::FfiBuffer::new(&mut buffer);
+        //         match (api.serial_read)(uart_dev, wrapper, neotron_common_bios::FfiOption::None) {
+        //             neotron_common_bios::ApiResult::Ok(n) if n >= 0 => {
+        //                 self.buffer.enqueue(buffer[0]).unwrap();
+        //             }
+        //             _ => {
+        //                 break;
+        //             }
+        //         }
+        //     }
+        // }
+
+        self.get_buffered_data(buffer)
+    }
+}
+
 // ===========================================================================
 // Macros
 // ===========================================================================
@@ -176,7 +291,6 @@ impl core::fmt::Write for SerialConsole {
 
 pub struct Ctx {
     config: config::Config,
-    keyboard: pc_keyboard::EventDecoder<pc_keyboard::layouts::AnyLayout>,
     tpa: program::TransientProgramArea,
 }
 
@@ -287,10 +401,6 @@ pub extern "C" fn os_main(api: &bios::Api) -> ! {
 
     let mut ctx = Ctx {
         config,
-        keyboard: pc_keyboard::EventDecoder::new(
-            pc_keyboard::layouts::AnyLayout::Uk105Key(pc_keyboard::layouts::Uk105Key),
-            pc_keyboard::HandleControl::MapLettersToUnicode,
-        ),
         tpa: unsafe {
             // We have to trust the values given to us by the BIOS. If it lies, we will crash.
             program::TransientProgramArea::new(tpa_start, tpa_size)
@@ -310,68 +420,10 @@ pub extern "C" fn os_main(api: &bios::Api) -> ! {
     let mut menu = menu::Runner::new(&commands::OS_MENU, &mut buffer, ctx);
 
     loop {
-        match (api.hid_get_event)() {
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyPress(code))) => {
-                let pckb_ev = pc_keyboard::KeyEvent {
-                    code,
-                    state: pc_keyboard::KeyState::Down,
-                };
-                if let Some(pc_keyboard::DecodedKey::Unicode(mut ch)) =
-                    menu.context.keyboard.process_keyevent(pckb_ev)
-                {
-                    if ch == '\n' {
-                        ch = '\r';
-                    }
-                    let mut buffer = [0u8; 6];
-                    let s = ch.encode_utf8(&mut buffer);
-                    for b in s.as_bytes() {
-                        menu.input_byte(*b);
-                    }
-                }
-            }
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::KeyRelease(code))) => {
-                let pckb_ev = pc_keyboard::KeyEvent {
-                    code,
-                    state: pc_keyboard::KeyState::Up,
-                };
-                if let Some(pc_keyboard::DecodedKey::Unicode(ch)) =
-                    menu.context.keyboard.process_keyevent(pckb_ev)
-                {
-                    let mut buffer = [0u8; 6];
-                    let s = ch.encode_utf8(&mut buffer);
-                    for b in s.as_bytes() {
-                        menu.input_byte(*b);
-                    }
-                }
-            }
-            bios::ApiResult::Ok(bios::FfiOption::Some(bios::hid::HidEvent::MouseInput(
-                _ignore,
-            ))) => {}
-            bios::ApiResult::Ok(bios::FfiOption::None) => {
-                // Do nothing
-            }
-            bios::ApiResult::Err(e) => {
-                osprintln!("Failed to get HID events: {:?}", e);
-            }
-        }
-        if let Some((uart_dev, _serial_conf)) = menu.context.config.get_serial_console() {
-            loop {
-                let mut buffer = [0u8; 8];
-                let wrapper = neotron_common_bios::FfiBuffer::new(&mut buffer);
-                match (api.serial_read)(uart_dev, wrapper, neotron_common_bios::FfiOption::None) {
-                    neotron_common_bios::ApiResult::Ok(n) if n == 0 => {
-                        break;
-                    }
-                    neotron_common_bios::ApiResult::Ok(n) => {
-                        for b in &buffer[0..n] {
-                            menu.input_byte(*b);
-                        }
-                    }
-                    _ => {
-                        break;
-                    }
-                }
-            }
+        let mut buffer = [0u8; 16];
+        let count = unsafe { STD_INPUT.get_data(&mut buffer) };
+        for b in &buffer[0..count] {
+            menu.input_byte(*b);
         }
         (api.power_idle)();
     }

--- a/src/program.rs
+++ b/src/program.rs
@@ -319,15 +319,13 @@ extern "C" fn api_write(
     buffer: neotron_api::FfiByteSlice,
 ) -> neotron_api::Result<()> {
     if fd == neotron_api::file::Handle::new_stdout() {
-        let mut guard = crate::VGA_CONSOLE.try_lock().unwrap();
+        let mut guard = crate::VGA_CONSOLE.lock();
         if let Some(console) = guard.as_mut() {
             console.write_bstr(buffer.as_slice());
         }
-        let mut guard = crate::SERIAL_CONSOLE.try_lock().unwrap();
+        let mut guard = crate::SERIAL_CONSOLE.lock();
         if let Some(console) = guard.as_mut() {
-            if let Err(_e) = console.write_bstr(buffer.as_slice()) {
-                return neotron_api::Result::Err(neotron_api::Error::DeviceSpecific);
-            }
+            console.write_bstr(buffer.as_slice());
         }
         neotron_api::Result::Ok(())
     } else {

--- a/src/program.rs
+++ b/src/program.rs
@@ -337,10 +337,19 @@ extern "C" fn api_write(
 ///
 /// If you hit the end of the file, you might get less data than you asked for.
 extern "C" fn api_read(
-    _fd: neotron_api::file::Handle,
-    _buffer: neotron_api::FfiBuffer,
+    fd: neotron_api::file::Handle,
+    mut buffer: neotron_api::FfiBuffer,
 ) -> neotron_api::Result<usize> {
-    neotron_api::Result::Err(neotron_api::Error::Unimplemented)
+    if fd == neotron_api::file::Handle::new_stdin() {
+        if let Some(buffer) = buffer.as_mut_slice() {
+            let count = unsafe { crate::STD_INPUT.get_data(buffer) };
+            Ok(count).into()
+        } else {
+            neotron_api::Result::Err(neotron_api::Error::DeviceSpecific)
+        }
+    } else {
+        neotron_api::Result::Err(neotron_api::Error::BadHandle)
+    }
 }
 
 /// Move the file offset (for the given file handle) to the given position.

--- a/src/refcell.rs
+++ b/src/refcell.rs
@@ -1,0 +1,156 @@
+//! # RefCells for Neotron OS.
+//!
+//! Like the `RefCell` in the standard library, except that it's thread-safe
+//! and uses the BIOS critical section to make it so.
+
+// ===========================================================================
+// Modules and Imports
+// ===========================================================================
+
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+// ===========================================================================
+// Global Variables
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// Macros
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// Public types
+// ===========================================================================
+
+/// Indicates a failure to lock the refcell because it was already locked.
+#[derive(Debug)]
+pub struct LockError;
+
+/// A cell that gives you references, and is thread-safe.
+///
+/// Uses the BIOS to ensure thread-safety whilst checking if the lock is taken
+/// or not.
+pub struct CsRefCell<T> {
+    inner: UnsafeCell<T>,
+    locked: AtomicBool,
+}
+
+impl<T> CsRefCell<T> {
+    /// Create a new cell.
+    pub const fn new(value: T) -> CsRefCell<T> {
+        CsRefCell {
+            inner: UnsafeCell::new(value),
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    /// Try and do something with the lock.
+    pub fn with<F, U>(&self, f: F) -> Result<U, LockError>
+    where
+        F: FnOnce(&mut CsRefCellGuard<T>) -> U,
+    {
+        let mut guard = self.try_lock()?;
+        let result = f(&mut guard);
+        drop(guard);
+        Ok(result)
+    }
+
+    /// Lock the cell.
+    ///
+    /// If you can't lock it (because it is already locked), this function will panic.
+    pub fn lock(&self) -> CsRefCellGuard<T> {
+        self.try_lock().unwrap()
+    }
+
+    /// Try and grab the lock.
+    ///
+    /// It'll fail if it's already been taken.
+    ///
+    /// It'll panic if the global lock is in a bad state, or you try and
+    /// re-enter this function from an interrupt whilst the global lock is held.
+    /// Don't do that.
+    pub fn try_lock(&self) -> Result<CsRefCellGuard<T>, LockError> {
+        let api = crate::API.get();
+
+        if (api.compare_and_swap_bool)(&self.locked, false, true) {
+            // succesfully swapped `false` for `true`
+            core::sync::atomic::fence(Ordering::Acquire);
+            Ok(CsRefCellGuard { parent: self })
+        } else {
+            // cell is already locked
+            Err(LockError)
+        }
+    }
+}
+
+/// Mark our type as thread-safe.
+///
+/// # Safety
+///
+/// We use the BIOS critical sections to control access to the global lock, and
+/// refcell locks are only tested whilst holding the global lock. Thus it is now
+/// thread-safe.
+unsafe impl<T> Sync for CsRefCell<T> {}
+
+/// Represents an active borrow of a [`CsRefCell`].
+pub struct CsRefCellGuard<'a, T> {
+    parent: &'a CsRefCell<T>,
+}
+
+impl<'a, T> Deref for CsRefCellGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        let ptr = self.parent.inner.get();
+        unsafe { &*ptr }
+    }
+}
+
+impl<'a, T> DerefMut for CsRefCellGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let ptr = self.parent.inner.get();
+        unsafe { &mut *ptr }
+    }
+}
+
+impl<'a, T> Drop for CsRefCellGuard<'a, T> {
+    fn drop(&mut self) {
+        // We hold this refcell guard exclusively, so this can't race
+        self.parent.locked.store(false, Ordering::Release);
+    }
+}
+
+// ===========================================================================
+// Private types
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// Private functions
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// Public functions
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+// None
+
+// ===========================================================================
+// End of file
+// ===========================================================================

--- a/src/refcell.rs
+++ b/src/refcell.rs
@@ -94,8 +94,7 @@ impl<T> CsRefCell<T> {
 ///
 /// # Safety
 ///
-/// We use the BIOS critical sections to control access to the global lock, and
-/// refcell locks are only tested whilst holding the global lock. Thus it is now
+/// We use the BIOS critical sections to control access. Thus it is now
 /// thread-safe.
 unsafe impl<T> Sync for CsRefCell<T> {}
 


### PR DESCRIPTION
It's not nice, because I put the keyboard decoding into a static mut. Really, this should be in a mutex. But to make a mutex you need compare-and-swap, and ARMv6-M doesn't have that, and the work-around is very hardware specific.

So, I think we need a critical-section implementation for the OS which uses the BIOS to acquire and release the lock. We can then use atomic-polyfill to provide compare-and-swap as we do on the Neotron Pico BIOS.

Also I lost the serial input because that's currently in the menu context and we can't access that from OS API callbacks.