### PR TITLE
Clean up console handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 [[package]]
 name = "utf8parse"
 version = "0.2.1"
-source = "git+https://github.com/alacritty/vte#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
+source = "git+https://github.com/alacritty/vte?rev=94e74f3a64f42d5dad4e3d42dbe8c23291038214#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
 
 [[package]]
 name = "void"
@@ -325,7 +325,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 [[package]]
 name = "vte"
 version = "0.11.1"
-source = "git+https://github.com/alacritty/vte#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
+source = "git+https://github.com/alacritty/vte?rev=94e74f3a64f42d5dad4e3d42dbe8c23291038214#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
 dependencies = [
  "arrayvec",
  "utf8parse",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "vte_generate_state_changes"
 version = "0.1.1"
-source = "git+https://github.com/alacritty/vte#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
+source = "git+https://github.com/alacritty/vte?rev=94e74f3a64f42d5dad4e3d42dbe8c23291038214#94e74f3a64f42d5dad4e3d42dbe8c23291038214"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", default-features = false }
 embedded-sdmmc = { version = "0.5", default-features = false }
 neotron-api = "0.1"
 neotron-loader = "0.1"
-vte = { git = "https://github.com/alacritty/vte", commit="94e74f3a64f42d5dad4e3d42dbe8c23291038214" }
+vte = { git = "https://github.com/alacritty/vte", rev = "94e74f3a64f42d5dad4e3d42dbe8c23291038214" }
 
 [features]
 lib-mode = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 // Modules and Imports
 // ===========================================================================
 
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
 use neotron_common_bios as bios;
 
@@ -45,6 +45,12 @@ static VGA_CONSOLE: CsRefCell<Option<vgaconsole::VgaConsole>> = CsRefCell::new(N
 /// We store our serial console here.
 static SERIAL_CONSOLE: CsRefCell<Option<SerialConsole>> = CsRefCell::new(None);
 
+/// Our overall text output console.
+///
+/// Writes to the VGA console and/or the serial console (depending on which is
+/// configured).
+static CONSOLE: Console = Console;
+
 /// Note if we are panicking right now.
 ///
 /// If so, don't panic if a serial write fails.
@@ -53,6 +59,157 @@ static IS_PANIC: AtomicBool = AtomicBool::new(false);
 /// Our keyboard controller
 static STD_INPUT: CsRefCell<StdInput> = CsRefCell::new(StdInput::new());
 
+// ===========================================================================
+// Macros
+// ===========================================================================
+
+/// Prints to the screen
+#[macro_export]
+macro_rules! osprint {
+    ($($arg:tt)*) => {
+        #[allow(unused)]
+        use core::fmt::Write as _;
+        let _ = write!(&$crate::CONSOLE, $($arg)*);
+    }
+}
+
+/// Prints to the screen and puts a new-line on the end
+#[macro_export]
+macro_rules! osprintln {
+    () => ($crate::osprint!("\n"));
+    ($($arg:tt)*) => {
+        $crate::osprint!($($arg)*);
+        $crate::osprint!("\n");
+    };
+}
+
+// ===========================================================================
+// Local types
+// ===========================================================================
+
+/// Represents the API supplied by the BIOS
+struct Api {
+    bios: AtomicPtr<bios::Api>,
+}
+
+impl Api {
+    /// Create a new object with a null pointer for the BIOS API.
+    const fn new() -> Api {
+        Api {
+            bios: AtomicPtr::new(core::ptr::null_mut()),
+        }
+    }
+
+    /// Change the stored BIOS API pointer.
+    ///
+    /// The pointed-at object must have static lifetime.
+    unsafe fn store(&self, api: *const bios::Api) {
+        self.bios.store(api as *mut bios::Api, Ordering::SeqCst)
+    }
+
+    /// Get the BIOS API as a reference.
+    ///
+    /// Will panic if the stored pointer is null.
+    fn get(&self) -> &'static bios::Api {
+        let ptr = self.bios.load(Ordering::SeqCst) as *const bios::Api;
+        let api_ref = unsafe { ptr.as_ref() }.expect("BIOS API should be non-null");
+        api_ref
+    }
+
+    /// Get the current time
+    fn get_time(&self) -> chrono::NaiveDateTime {
+        let api = self.get();
+        let bios_time = (api.time_clock_get)();
+        let secs = i64::from(bios_time.secs) + SECONDS_BETWEEN_UNIX_AND_NEOTRON_EPOCH;
+        let nsecs = bios_time.nsecs;
+        chrono::NaiveDateTime::from_timestamp_opt(secs, nsecs).unwrap()
+    }
+
+    /// Set the current time
+    fn set_time(&self, timestamp: chrono::NaiveDateTime) {
+        let api = self.get();
+        let nanos = timestamp.timestamp_nanos();
+        let bios_time = bios::Time {
+            secs: ((nanos / 1_000_000_000) - SECONDS_BETWEEN_UNIX_AND_NEOTRON_EPOCH) as u32,
+            nsecs: (nanos % 1_000_000_000) as u32,
+        };
+        (api.time_clock_set)(bios_time);
+    }
+}
+
+/// Represents the serial port we can use as a text input/output device.
+struct SerialConsole(u8);
+
+impl SerialConsole {
+    /// Write some bytes to the serial console
+    fn write_bstr(&mut self, mut data: &[u8]) -> Result<(), bios::Error> {
+        let api = API.get();
+        while !data.is_empty() {
+            let res: Result<usize, bios::Error> = (api.serial_write)(
+                // Which port
+                self.0,
+                // Data
+                bios::FfiByteSlice::new(data),
+                // No timeout
+                bios::FfiOption::None,
+            )
+            .into();
+            let count = match res {
+                Ok(n) => n,
+                Err(_e) => {
+                    // If we can't write to the serial port, let's not break any
+                    // other consoles we might have configured. Instead, just
+                    // quit now and pretend we wrote it all.
+                    return Ok(());
+                }
+            };
+            data = &data[count..];
+        }
+        Ok(())
+    }
+
+    /// Try and get as many bytes as we can from the serial console.
+    fn read_data(&mut self, buffer: &mut [u8]) -> Result<usize, bios::Error> {
+        let api = API.get();
+        let ffi_buffer = bios::FfiBuffer::new(buffer);
+        let res = (api.serial_read)(
+            self.0,
+            ffi_buffer,
+            bios::FfiOption::Some(bios::Timeout::new_ms(0)),
+        );
+        res.into()
+    }
+}
+
+impl core::fmt::Write for SerialConsole {
+    fn write_str(&mut self, data: &str) -> core::fmt::Result {
+        self.write_bstr(data.as_bytes())
+            .map_err(|_e| core::fmt::Error)
+    }
+}
+
+/// Represents either or both of the VGA console and the serial console.
+struct Console;
+
+impl core::fmt::Write for &Console {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        if let Ok(mut guard) = VGA_CONSOLE.try_lock() {
+            if let Some(vga_console) = guard.as_mut() {
+                vga_console.write_str(s)?;
+            }
+        }
+
+        if let Ok(mut guard) = SERIAL_CONSOLE.try_lock() {
+            if let Some(serial_console) = guard.as_mut() {
+                serial_console.write_str(s)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Represents the standard input of our console
 struct StdInput {
     keyboard: pc_keyboard::EventDecoder<pc_keyboard::layouts::AnyLayout>,
     buffer: heapless::spsc::Queue<u8, 16>,
@@ -161,149 +318,10 @@ impl StdInput {
     }
 }
 
-// ===========================================================================
-// Macros
-// ===========================================================================
-
-/// Prints to the screen
-#[macro_export]
-macro_rules! osprint {
-    ($($arg:tt)*) => {
-        $crate::VGA_CONSOLE.with(|guard| {
-            if let Some(console) = guard.as_mut() {
-                #[allow(unused)]
-                use core::fmt::Write as _;
-                write!(console, $($arg)*).unwrap();
-            }
-        }).unwrap();
-        $crate::SERIAL_CONSOLE.with(|guard| {
-            if let Some(console) = guard.as_mut() {
-                #[allow(unused)]
-                use core::fmt::Write as _;
-                write!(console, $($arg)*).unwrap();
-            }
-        }).unwrap();
-    };
-}
-
-/// Prints to the screen and puts a new-line on the end
-#[macro_export]
-macro_rules! osprintln {
-    () => ($crate::osprint!("\n"));
-    ($($arg:tt)*) => {
-        $crate::osprint!($($arg)*);
-        $crate::osprint!("\n");
-    };
-}
-
-// ===========================================================================
-// Local types
-// ===========================================================================
-
-/// Represents the API supplied by the BIOS
-struct Api {
-    bios: core::sync::atomic::AtomicPtr<bios::Api>,
-}
-
-impl Api {
-    /// Create a new object with a null pointer for the BIOS API.
-    const fn new() -> Api {
-        Api {
-            bios: core::sync::atomic::AtomicPtr::new(core::ptr::null_mut()),
-        }
-    }
-
-    /// Change the stored BIOS API pointer.
-    ///
-    /// The pointed-at object must have static lifetime.
-    unsafe fn store(&self, api: *const bios::Api) {
-        self.bios
-            .store(api as *mut bios::Api, core::sync::atomic::Ordering::SeqCst)
-    }
-
-    /// Get the BIOS API as a reference.
-    ///
-    /// Will panic if the stored pointer is null.
-    fn get(&self) -> &'static bios::Api {
-        let ptr = self.bios.load(core::sync::atomic::Ordering::SeqCst) as *const bios::Api;
-        let api_ref = unsafe { ptr.as_ref() }.expect("BIOS API should be non-null");
-        api_ref
-    }
-
-    /// Get the current time
-    fn get_time(&self) -> chrono::NaiveDateTime {
-        let api = self.get();
-        let bios_time = (api.time_clock_get)();
-        let secs = i64::from(bios_time.secs) + SECONDS_BETWEEN_UNIX_AND_NEOTRON_EPOCH;
-        let nsecs = bios_time.nsecs;
-        chrono::NaiveDateTime::from_timestamp_opt(secs, nsecs).unwrap()
-    }
-
-    /// Set the current time
-    fn set_time(&self, timestamp: chrono::NaiveDateTime) {
-        let api = self.get();
-        let nanos = timestamp.timestamp_nanos();
-        let bios_time = bios::Time {
-            secs: ((nanos / 1_000_000_000) - SECONDS_BETWEEN_UNIX_AND_NEOTRON_EPOCH) as u32,
-            nsecs: (nanos % 1_000_000_000) as u32,
-        };
-        (api.time_clock_set)(bios_time);
-    }
-}
-
-/// Represents the serial port we can use as a text input/output device.
-struct SerialConsole(u8);
-
-impl SerialConsole {
-    /// Write some bytes to the serial console
-    fn write_bstr(&mut self, data: &[u8]) {
-        let api = API.get();
-        let is_panic = IS_PANIC.load(Ordering::Relaxed);
-        let res = (api.serial_write)(
-            // Which port
-            self.0,
-            // Data
-            bios::FfiByteSlice::new(data),
-            // No timeout
-            bios::FfiOption::None,
-        );
-        if !is_panic {
-            res.unwrap();
-        }
-    }
-
-    /// Try and get as many bytes as we can from the serial console.
-    fn read_data(&mut self, buffer: &mut [u8]) -> Result<usize, bios::Error> {
-        let api = API.get();
-        let ffi_buffer = bios::FfiBuffer::new(buffer);
-        let res = (api.serial_read)(
-            self.0,
-            ffi_buffer,
-            bios::FfiOption::Some(bios::Timeout::new_ms(0)),
-        );
-        res.into()
-    }
-}
-
-impl core::fmt::Write for SerialConsole {
-    fn write_str(&mut self, data: &str) -> core::fmt::Result {
-        let api = API.get();
-        let is_panic = IS_PANIC.load(Ordering::Relaxed);
-        let res = (api.serial_write)(
-            // Which port
-            self.0,
-            // Data
-            bios::FfiByteSlice::new(data.as_bytes()),
-            // No timeout
-            bios::FfiOption::None,
-        );
-        if !is_panic {
-            res.unwrap();
-        }
-        Ok(())
-    }
-}
-
+/// Local context used by the main menu.
+///
+/// Stuff goes here in preference, but we take it out of here and make it a
+/// global if we have to.
 pub struct Ctx {
     config: config::Config,
     tpa: program::TransientProgramArea,

--- a/src/program.rs
+++ b/src/program.rs
@@ -325,7 +325,8 @@ extern "C" fn api_write(
         }
         let mut guard = crate::SERIAL_CONSOLE.lock();
         if let Some(console) = guard.as_mut() {
-            console.write_bstr(buffer.as_slice());
+            // Ignore serial errors on stdout
+            let _ = console.write_bstr(buffer.as_slice());
         }
         neotron_api::Result::Ok(())
     } else {

--- a/src/refcell.rs
+++ b/src/refcell.rs
@@ -51,17 +51,6 @@ impl<T> CsRefCell<T> {
         }
     }
 
-    /// Try and do something with the lock.
-    pub fn with<F, U>(&self, f: F) -> Result<U, LockError>
-    where
-        F: FnOnce(&mut CsRefCellGuard<T>) -> U,
-    {
-        let mut guard = self.try_lock()?;
-        let result = f(&mut guard);
-        drop(guard);
-        Ok(result)
-    }
-
     /// Lock the cell.
     ///
     /// If you can't lock it (because it is already locked), this function will panic.


### PR DESCRIPTION
Avoids panics if serial console is configured but BIOS returns errors.