### PR TITLE
Add type and exec commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased changes
 
-* None
+* Add `i2c` command.
+* Support printing `\t`, with 8 character tab-stops
+* Add `type` command to print files
+* Add `exec` command to execute scripts containing commands
 
 ## v0.6.0  (2023-10-08, [Github Release](https://github.com/neotron-compute/neotron-os/releases/tag/v0.6.0))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,8 +75,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-sdmmc"
-version = "0.5.0"
-source = "git+https://github.com/rust-embedded-community/embedded-sdmmc-rs#e3f807f2727e4098a40b9cb831196aabb699f59b"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3778099e48fedd6b81048e1d84f60db663124f5c6e22fcef495040b9d51fe06a"
 dependencies = [
  "byteorder",
  "embedded-hal",

--- a/build.rs
+++ b/build.rs
@@ -31,3 +31,5 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=msvcrt");
     }
 }
+
+// End of file

--- a/src/bin/flash0002.rs
+++ b/src/bin/flash0002.rs
@@ -14,3 +14,5 @@
 #[link_section = ".entry_point"]
 #[used]
 pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;
+
+// End of file

--- a/src/bin/flash0802.rs
+++ b/src/bin/flash0802.rs
@@ -14,3 +14,5 @@
 #[link_section = ".entry_point"]
 #[used]
 pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;
+
+// End of file

--- a/src/bin/flash1002.rs
+++ b/src/bin/flash1002.rs
@@ -14,3 +14,5 @@
 #[link_section = ".entry_point"]
 #[used]
 pub static ENTRY_POINT_ADDR: extern "C" fn(&neotron_common_bios::Api) -> ! = neotron_os::os_main;
+
+// End of file

--- a/src/commands/block.rs
+++ b/src/commands/block.rs
@@ -1,15 +1,7 @@
 //! Block Device related commands for Neotron OS
 
+use super::{parse_u64, parse_u8};
 use crate::{bios, osprint, osprintln, Ctx, API};
-
-pub static LSBLK_ITEM: menu::Item<Ctx> = menu::Item {
-    item_type: menu::ItemType::Callback {
-        function: lsblk,
-        parameters: &[],
-    },
-    command: "lsblk",
-    help: Some("List all the Block Devices"),
-};
 
 pub static READ_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
@@ -29,66 +21,21 @@ pub static READ_ITEM: menu::Item<Ctx> = menu::Item {
     help: Some("Display one disk block, as hex"),
 };
 
-/// Called when the "lsblk" command is executed.
-fn lsblk(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
-    let api = API.get();
-    let mut found = false;
-
-    osprintln!("Block Devices:");
-    for dev_idx in 0..=255u8 {
-        if let bios::FfiOption::Some(device_info) = (api.block_dev_get_info)(dev_idx) {
-            let (bsize, bunits, dsize, dunits) =
-                match device_info.num_blocks * u64::from(device_info.block_size) {
-                    x if x < (1024 * 1024 * 1024) => {
-                        // Under 1 GiB, give it in 10s of MiB
-                        (10 * x / (1024 * 1024), "MiB", x / 100_000, "MB")
-                    }
-                    x => {
-                        // Anything else in GiB
-                        (10 * x / (1024 * 1024 * 1024), "GiB", x / 100_000_000, "GB")
-                    }
-                };
-            osprintln!("Device {}:", dev_idx);
-            osprintln!("          Name: {}", device_info.name);
-            osprintln!("          Type: {:?}", device_info.device_type);
-            osprintln!("    Block size: {}", device_info.block_size);
-            osprintln!("    Num Blocks: {}", device_info.num_blocks);
-            osprintln!(
-                "     Card Size: {}.{} {} ({}.{} {})",
-                bsize / 10,
-                bsize % 10,
-                bunits,
-                dsize / 10,
-                dsize % 10,
-                dunits
-            );
-            osprintln!("     Ejectable: {}", device_info.ejectable);
-            osprintln!("     Removable: {}", device_info.removable);
-            osprintln!(" Media Present: {}", device_info.media_present);
-            osprintln!("     Read Only: {}", device_info.read_only);
-            found = true;
-        }
-    }
-    if !found {
-        osprintln!("  None");
-    }
-}
-
 /// Called when the "read_block" command is executed.
 fn read_block(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], _ctx: &mut Ctx) {
     let api = API.get();
-    let Ok(dev_idx) = args[0].parse::<u8>() else {
+    let Ok(device_idx) = parse_u8(args[0]) else {
         osprintln!("Couldn't parse {:?}", args[0]);
         return;
     };
-    let Ok(block_idx) = args[1].parse::<u64>() else {
+    let Ok(block_idx) = parse_u64(args[1]) else {
         osprintln!("Couldn't parse {:?}", args[1]);
         return;
     };
     osprintln!("Reading block {}:", block_idx);
     let mut buffer = [0u8; 512];
     match (api.block_read)(
-        dev_idx,
+        device_idx,
         bios::block_dev::BlockIdx(block_idx),
         1,
         bios::FfiBuffer::new(&mut buffer),
@@ -110,3 +57,5 @@ fn read_block(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], _
         }
     }
 }
+
+// End of file

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -106,3 +106,5 @@ fn command(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx:
         }
     }
 }
+
+// End of file

--- a/src/commands/fs.rs
+++ b/src/commands/fs.rs
@@ -1,7 +1,5 @@
 //! File Systems related commands for Neotron OS
 
-use embedded_sdmmc::VolumeIdx;
-
 use crate::{bios, osprint, osprintln, Ctx};
 
 pub static DIR_ITEM: menu::Item<Ctx> = menu::Item {
@@ -25,6 +23,18 @@ pub static LOAD_ITEM: menu::Item<Ctx> = menu::Item {
     help: Some("Load a file into the application area"),
 };
 
+pub static EXEC_ITEM: menu::Item<Ctx> = menu::Item {
+    item_type: menu::ItemType::Callback {
+        function: exec,
+        parameters: &[menu::Parameter::Mandatory {
+            parameter_name: "file",
+            help: Some("The shell script to run"),
+        }],
+    },
+    command: "exec",
+    help: Some("Execute a shell script"),
+};
+
 pub static TYPE_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
         function: typefn,
@@ -45,7 +55,7 @@ fn dir(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &
         let time = crate::fs::BiosTime();
         let mut mgr = embedded_sdmmc::VolumeManager::new(bios_block, time);
         // Open the first partition
-        let volume = mgr.open_volume(VolumeIdx(0))?;
+        let volume = mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
         let root_dir = mgr.open_root_dir(volume)?;
         let mut total_bytes = 0u64;
         let mut num_files = 0;
@@ -112,6 +122,41 @@ fn load(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &m
     }
 }
 
+/// Called when the "exec" command is executed.
+fn exec(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &mut Ctx) {
+    fn work(ctx: &mut Ctx, filename: &str) -> Result<(), embedded_sdmmc::Error<bios::Error>> {
+        let bios_block = crate::fs::BiosBlock();
+        let time = crate::fs::BiosTime();
+        let mut mgr = embedded_sdmmc::VolumeManager::new(bios_block, time);
+        // Open the first partition
+        let volume = mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
+        let root_dir = mgr.open_root_dir(volume)?;
+        let file = mgr.open_file_in_dir(root_dir, filename, embedded_sdmmc::Mode::ReadOnly)?;
+        let buffer = ctx.tpa.as_slice_u8();
+        let count = mgr.read(file, buffer)?;
+        if count != mgr.file_length(file)? as usize {
+            osprintln!("File too large! Max {} bytes allowed.", buffer.len());
+            return Ok(());
+        }
+        let Ok(s) = core::str::from_utf8(&buffer[0..count]) else {
+            osprintln!("File is not valid UTF-8");
+            return Ok(());
+        };
+        // tell the main loop to run from these bytes next
+        ctx.exec_tpa = Some(s.len());
+        Ok(())
+    }
+
+    // index can't panic - we always have enough args
+    let r = work(ctx, args[0]);
+    match r {
+        Ok(_) => {}
+        Err(e) => {
+            osprintln!("Error: {:?}", e);
+        }
+    }
+}
+
 /// Called when the "type" command is executed.
 fn typefn(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &mut Ctx) {
     fn work(ctx: &mut Ctx, filename: &str) -> Result<(), embedded_sdmmc::Error<bios::Error>> {
@@ -119,7 +164,7 @@ fn typefn(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: 
         let time = crate::fs::BiosTime();
         let mut mgr = embedded_sdmmc::VolumeManager::new(bios_block, time);
         // Open the first partition
-        let volume = mgr.open_volume(VolumeIdx(0))?;
+        let volume = mgr.open_volume(embedded_sdmmc::VolumeIdx(0))?;
         let root_dir = mgr.open_root_dir(volume)?;
         let file = mgr.open_file_in_dir(root_dir, filename, embedded_sdmmc::Mode::ReadOnly)?;
         let buffer = ctx.tpa.as_slice_u8();

--- a/src/commands/fs.rs
+++ b/src/commands/fs.rs
@@ -25,6 +25,18 @@ pub static LOAD_ITEM: menu::Item<Ctx> = menu::Item {
     help: Some("Load a file into the application area"),
 };
 
+pub static TYPE_ITEM: menu::Item<Ctx> = menu::Item {
+    item_type: menu::ItemType::Callback {
+        function: typefn,
+        parameters: &[menu::Parameter::Mandatory {
+            parameter_name: "file",
+            help: Some("The file to type"),
+        }],
+    },
+    command: "type",
+    help: Some("Type a file to the console"),
+};
+
 /// Called when the "dir" command is executed.
 fn dir(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx: &mut Ctx) {
     fn work() -> Result<(), embedded_sdmmc::Error<bios::Error>> {
@@ -99,3 +111,41 @@ fn load(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &m
         }
     }
 }
+
+/// Called when the "type" command is executed.
+fn typefn(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &mut Ctx) {
+    fn work(ctx: &mut Ctx, filename: &str) -> Result<(), embedded_sdmmc::Error<bios::Error>> {
+        let bios_block = crate::fs::BiosBlock();
+        let time = crate::fs::BiosTime();
+        let mut mgr = embedded_sdmmc::VolumeManager::new(bios_block, time);
+        // Open the first partition
+        let volume = mgr.open_volume(VolumeIdx(0))?;
+        let root_dir = mgr.open_root_dir(volume)?;
+        let file = mgr.open_file_in_dir(root_dir, filename, embedded_sdmmc::Mode::ReadOnly)?;
+        let buffer = ctx.tpa.as_slice_u8();
+        let count = mgr.read(file, buffer)?;
+        if count != mgr.file_length(file)? as usize {
+            osprintln!("File too large! Max {} bytes allowed.", buffer.len());
+            return Ok(());
+        }
+        let Ok(s) = core::str::from_utf8(&buffer[0..count]) else {
+            osprintln!("File is not valid UTF-8");
+            return Ok(());
+        };
+        osprintln!("{}", s);
+        Ok(())
+    }
+
+    // index can't panic - we always have enough args
+    let r = work(ctx, args[0]);
+    // reset SGR
+    osprint!("\u{001b}[0m");
+    match r {
+        Ok(_) => {}
+        Err(e) => {
+            osprintln!("Error: {:?}", e);
+        }
+    }
+}
+
+// End of file

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -2,6 +2,8 @@
 
 use crate::{bios, osprintln, Ctx, API};
 
+use super::{parse_u8, parse_usize};
+
 pub static LSBLK_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
         function: lsblk,
@@ -63,6 +65,32 @@ pub static SHUTDOWN_ITEM: menu::Item<Ctx> = menu::Item {
     },
     command: "shutdown",
     help: Some("Shutdown the system"),
+};
+
+pub static I2C_ITEM: menu::Item<Ctx> = menu::Item {
+    item_type: menu::ItemType::Callback {
+        function: i2c,
+        parameters: &[
+            menu::Parameter::Mandatory {
+                parameter_name: "bus_idx",
+                help: Some("I2C bus index"),
+            },
+            menu::Parameter::Mandatory {
+                parameter_name: "dev_addr",
+                help: Some("7-bit I2C device address"),
+            },
+            menu::Parameter::Mandatory {
+                parameter_name: "tx_bytes",
+                help: Some("Hex string to transmit"),
+            },
+            menu::Parameter::Mandatory {
+                parameter_name: "rx_count",
+                help: Some("How many bytes to receive"),
+            },
+        ],
+    },
+    command: "i2c",
+    help: Some("Do an I2C transaction on a bus"),
 };
 
 /// Called when the "lsblk" command is executed.
@@ -195,7 +223,6 @@ fn lsuart(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx
 /// Called when the "shutdown" command is executed.
 fn shutdown(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx: &mut Ctx) {
     let api = API.get();
-
     if let Ok(Some(_)) = menu::argument_finder(item, args, "reboot") {
         osprintln!("Rebooting...");
         (api.power_control)(bios::PowerMode::Reset);
@@ -205,6 +232,101 @@ fn shutdown(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx
     } else {
         osprintln!("Shutting down...");
         (api.power_control)(bios::PowerMode::Off);
+    }
+}
+
+/// Called when the "i2c" command is executed.
+fn i2c(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx: &mut Ctx) {
+    let bus_idx = menu::argument_finder(item, args, "bus_idx").unwrap();
+    let dev_addr = menu::argument_finder(item, args, "dev_addr").unwrap();
+    let tx_bytes = menu::argument_finder(item, args, "tx_bytes").unwrap();
+    let rx_count = menu::argument_finder(item, args, "rx_count").unwrap();
+
+    let (Some(bus_idx), Some(dev_addr), Some(tx_bytes), Some(rx_count)) =
+        (bus_idx, dev_addr, tx_bytes, rx_count)
+    else {
+        osprintln!("Missing arguments.");
+        return;
+    };
+
+    let mut tx_buffer: heapless::Vec<u8, 16> = heapless::Vec::new();
+
+    for hex_pair in tx_bytes.as_bytes().chunks(2) {
+        let Some(top) = hex_digit(hex_pair[0]) else {
+            osprintln!("Bad hex.");
+            return;
+        };
+        let Some(bottom) = hex_digit(hex_pair[1]) else {
+            osprintln!("Bad hex.");
+            return;
+        };
+        let byte = top << 4 | bottom;
+        let Ok(_) = tx_buffer.push(byte) else {
+            osprintln!("Too much hex.");
+            return;
+        };
+    }
+
+    let Ok(bus_idx) = parse_u8(bus_idx) else {
+        osprintln!("Bad bus_idx");
+        return;
+    };
+
+    let Ok(dev_addr) = parse_u8(dev_addr) else {
+        osprintln!("Bad dev_addr");
+        return;
+    };
+
+    let Ok(rx_count) = parse_usize(rx_count) else {
+        osprintln!("Bad rx count.");
+        return;
+    };
+
+    let mut rx_buf = [0u8; 16];
+
+    let Some(rx_buf) = rx_buf.get_mut(0..rx_count) else {
+        osprintln!("Too much rx.");
+        return;
+    };
+
+    let api = API.get();
+
+    match (api.i2c_write_read)(
+        bus_idx,
+        dev_addr,
+        tx_buffer.as_slice().into(),
+        bios::FfiByteSlice::empty(),
+        rx_buf.into(),
+    ) {
+        bios::FfiResult::Ok(_) => {
+            osprintln!("Ok, got {:x?}", rx_buf);
+        }
+        bios::FfiResult::Err(e) => {
+            osprintln!("Failed: {:?}", e);
+        }
+    }
+}
+
+/// Convert an ASCII hex digit into a number
+fn hex_digit(input: u8) -> Option<u8> {
+    match input {
+        b'0' => Some(0),
+        b'1' => Some(1),
+        b'2' => Some(2),
+        b'3' => Some(3),
+        b'4' => Some(4),
+        b'5' => Some(5),
+        b'6' => Some(6),
+        b'7' => Some(7),
+        b'8' => Some(8),
+        b'9' => Some(9),
+        b'a' | b'A' => Some(10),
+        b'b' | b'B' => Some(11),
+        b'c' | b'C' => Some(12),
+        b'd' | b'D' => Some(13),
+        b'e' | b'E' => Some(14),
+        b'f' | b'F' => Some(15),
+        _ => None,
     }
 }
 

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -42,3 +42,5 @@ fn kbtest(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], _ctx
     }
     osprintln!("Finished.");
 }
+
+// End of file

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,10 +19,13 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
     items: &[
         &timedate::DATE_ITEM,
         &config::COMMAND_ITEM,
-        &block::LSBLK_ITEM,
+        &hardware::LSBLK_ITEM,
+        &hardware::LSBUS_ITEM,
+        &hardware::LSI2C_ITEM,
+        &hardware::LSMEM_ITEM,
+        &hardware::LSUART_ITEM,
         &block::READ_ITEM,
         &fs::DIR_ITEM,
-        &hardware::LSHW_ITEM,
         &ram::HEXDUMP_ITEM,
         &ram::RUN_ITEM,
         &ram::LOAD_ITEM,
@@ -39,3 +42,44 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
     entry: None,
     exit: None,
 };
+
+/// Parse a string into a `usize`
+///
+/// Numbers like `0x123` are hex. Numbers like `123` are decimal.
+fn parse_usize(input: &str) -> Result<usize, core::num::ParseIntError> {
+    if let Some(digits) = input.strip_prefix("0x") {
+        // Parse as hex
+        usize::from_str_radix(digits, 16)
+    } else {
+        // Parse as decimal
+        input.parse::<usize>()
+    }
+}
+
+/// Parse a string into a `u8`
+///
+/// Numbers like `0x123` are hex. Numbers like `123` are decimal.
+fn parse_u8(input: &str) -> Result<u8, core::num::ParseIntError> {
+    if let Some(digits) = input.strip_prefix("0x") {
+        // Parse as hex
+        u8::from_str_radix(digits, 16)
+    } else {
+        // Parse as decimal
+        input.parse::<u8>()
+    }
+}
+
+/// Parse a string into a `u64`
+///
+/// Numbers like `0x123` are hex. Numbers like `123` are decimal.
+fn parse_u64(input: &str) -> Result<u64, core::num::ParseIntError> {
+    if let Some(digits) = input.strip_prefix("0x") {
+        // Parse as hex
+        u64::from_str_radix(digits, 16)
+    } else {
+        // Parse as decimal
+        input.parse::<u64>()
+    }
+}
+
+// End of file

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
         &ram::RUN_ITEM,
         &ram::LOAD_ITEM,
         &fs::LOAD_ITEM,
+        &fs::TYPE_ITEM,
         &screen::CLS_ITEM,
         &screen::MODE_ITEM,
         &input::KBTEST_ITEM,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -27,6 +27,7 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
         &ram::RUN_ITEM,
         &ram::LOAD_ITEM,
         &fs::LOAD_ITEM,
+        &fs::EXEC_ITEM,
         &fs::TYPE_ITEM,
         &screen::CLS_ITEM,
         &screen::MODE_ITEM,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub static OS_MENU: menu::Menu<Ctx> = menu::Menu {
         &hardware::LSI2C_ITEM,
         &hardware::LSMEM_ITEM,
         &hardware::LSUART_ITEM,
+        &hardware::I2C_ITEM,
         &block::READ_ITEM,
         &fs::DIR_ITEM,
         &ram::HEXDUMP_ITEM,

--- a/src/commands/ram.rs
+++ b/src/commands/ram.rs
@@ -1,5 +1,6 @@
 //! Raw RAM read/write related commands for Neotron OS
 
+use super::parse_usize;
 use crate::{osprint, osprintln, Ctx};
 
 pub static HEXDUMP_ITEM: menu::Item<Ctx> = menu::Item {
@@ -46,16 +47,6 @@ pub static LOAD_ITEM: menu::Item<Ctx> = menu::Item {
     command: "loadf",
     help: Some("Copy a program from ROM/RAM into the application area"),
 };
-
-fn parse_usize(input: &str) -> Result<usize, core::num::ParseIntError> {
-    if let Some(digits) = input.strip_prefix("0x") {
-        // Parse as hex
-        usize::from_str_radix(digits, 16)
-    } else {
-        // Parse as decimal
-        input.parse::<usize>()
-    }
-}
 
 /// Called when the "hexdump" command is executed.
 ///
@@ -146,3 +137,5 @@ fn loadf(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &
         }
     }
 }
+
+// End of file

--- a/src/commands/sound.rs
+++ b/src/commands/sound.rs
@@ -190,3 +190,5 @@ fn play(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &m
         osprintln!("\nError during playback: {:?}", e);
     }
 }
+
+// End of file

--- a/src/commands/sound.rs
+++ b/src/commands/sound.rs
@@ -99,7 +99,7 @@ fn mixer(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx: &
                         .unwrap_or(true)
                 {
                     osprintln!(
-                        "#{}: {} ({}) {}/{}",
+                        "\t{}: {} ({}) {}/{}",
                         mixer_id,
                         mixer_info.name,
                         dir_str,

--- a/src/commands/timedate.rs
+++ b/src/commands/timedate.rs
@@ -41,3 +41,5 @@ fn date(_menu: &menu::Menu<Ctx>, item: &menu::Item<Ctx>, args: &[&str], _ctx: &m
         time.nanosecond()
     );
 }
+
+// End of file

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,3 +88,5 @@ impl core::default::Default for Config {
         }
     }
 }
+
+// End of file

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -80,3 +80,5 @@ impl embedded_sdmmc::TimeSource for BiosTime {
         }
     }
 }
+
+// End of file

--- a/src/program.rs
+++ b/src/program.rs
@@ -177,12 +177,7 @@ impl TransientProgramArea {
 
     /// Borrow the TPA region as a slice of words
     pub fn as_slice_u32(&mut self) -> &mut [u32] {
-        unsafe {
-            core::slice::from_raw_parts_mut(
-                self.memory_bottom,
-                self.memory_top.offset_from(self.memory_bottom) as usize,
-            )
-        }
+        unsafe { core::slice::from_raw_parts_mut(self.memory_bottom, self.size_words()) }
     }
 
     /// Borrow the TPA region as a slice of bytes
@@ -190,10 +185,14 @@ impl TransientProgramArea {
         unsafe {
             core::slice::from_raw_parts_mut(
                 self.memory_bottom as *mut u8,
-                (self.memory_top.offset_from(self.memory_bottom) as usize)
-                    * core::mem::size_of::<u32>(),
+                self.size_words() * core::mem::size_of::<u32>(),
             )
         }
+    }
+
+    /// Size of the TPA in 32-bit words
+    fn size_words(&self) -> usize {
+        unsafe { self.memory_top.offset_from(self.memory_bottom) as usize }
     }
 
     /// Loads a program from disk into the Transient Program Area.
@@ -269,6 +268,38 @@ impl TransientProgramArea {
 
         self.last_entry = 0;
         Ok(result)
+    }
+
+    /// Move data to the top of TPA and make TPA shorter.
+    ///
+    /// Moves `size` bytes to the top of the TPA, and then pretends the TPA is
+    /// `size` bytes shorter than it was.
+    ///
+    /// `size` will be rounded up to a multiple of 4.
+    ///
+    /// Panics if `n` is too big to fit in the TPA.
+    ///
+    /// Returns a pointer to the data that now sits outside of the TPA. There
+    /// will be `size` bytes at this address but you must manage the lifetimes
+    /// yourself.
+    pub fn steal_top(&mut self, size: usize) -> *const u8 {
+        let stolen_words = (size + 3) / 4;
+        if stolen_words >= self.size_words() {
+            panic!("Stole too much from TPA!");
+        }
+        unsafe {
+            // Top goes down to free memory above it
+            let new_top = self.memory_top.sub(stolen_words);
+            // Copy the data from the bottom to above the newly reduced TPA
+            core::ptr::copy(self.memory_bottom, new_top, stolen_words);
+            new_top as *mut u8
+        }
+    }
+
+    /// Restore the TPA back where it was.
+    pub unsafe fn restore_top(&mut self, size: usize) {
+        let restored_words = (size + 3) / 4;
+        self.memory_top = self.memory_top.add(restored_words);
     }
 }
 

--- a/src/vgaconsole.rs
+++ b/src/vgaconsole.rs
@@ -199,12 +199,11 @@ impl ConsoleInner {
     /// We defer this so you can write the last char on the last line without
     /// causing it to scroll pre-emptively.
     fn scroll_as_required(&mut self) {
-        assert!(self.row <= self.height);
-        if self.col >= self.width {
-            self.col = 0;
+        while self.col >= self.width {
+            self.col -= self.width;
             self.row += 1;
         }
-        if self.row == self.height {
+        while self.row >= self.height {
             self.row -= 1;
             self.scroll_page();
         }
@@ -506,6 +505,9 @@ impl vte::Perform for ConsoleInner {
             }
             b'\r' => {
                 self.col = 0;
+            }
+            b'\t' => {
+                self.col = (self.col + 8) & !7;
             }
             b'\n' => {
                 self.col = 0;


### PR DESCRIPTION
You can now print UTF-8 files to the console, and execute files containing commands.

Executed scripts can load and run ELF binaries, but they cannot (currently) execute another script. This is a bit like SUBMIT for CP/M.

Now I've done this, I want to add a WAIT command to pause for a number of milliseconds. And I want to add Ctrl-C support through some kind of signal mechanism (scanning keyboard bytes for Ctrl-C