### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "b9b8634a088b9d5b338a96b3f6ef45a3bc0b9c0f0d562c7d00e498265fd96e8f"
 
 [[package]]
 name = "neotron-os"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "embedded-sdmmc",


### PR DESCRIPTION
The cargo lock file still though the crate was 0.6.0. This means the release build is marked as dirty.