### PR TITLE
Release/v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## Unreleased changes ([Source](https://github.com/neotron-compute/neotron-os/tree/develop) | [Changes](https://github.com/neotron-compute/neotron-os/compare/v0.7.0...develop))
+## Unreleased changes ([Source](https://github.com/neotron-compute/neotron-os/tree/develop) | [Changes](https://github.com/neotron-compute/neotron-os/compare/v0.7.1...develop))
 
 * None
+
+## v0.7.1 - 2023-10-21 ([Source](https://github.com/neotron-compute/neotron-os/tree/v0.7.1) | [Release](https://github.com/neotron-compute/neotron-os/releases/tag/v0.7.1))
+
+* Update `Cargo.lock` so build string no longer shows build as *dirty*
 
 ## v0.7.0 - 2023-10-21 ([Source](https://github.com/neotron-compute/neotron-os/tree/v0.7.0) | [Release](https://github.com/neotron-compute/neotron-os/releases/tag/v0.7.0))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "b9b8634a088b9d5b338a96b3f6ef45a3bc0b9c0f0d562c7d00e498265fd96e8f"
 
 [[package]]
 name = "neotron-os"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "embedded-sdmmc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neotron-os"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "The Neotron Developers"


### PR DESCRIPTION
* Update `Cargo.lock` so build string no longer shows build as *dirty*