### PR TITLE
Release/v0.8.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
           ./build.sh --verbose
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{success()}}
         with:
           name: Artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log
 
-## Unreleased changes ([Source](https://github.com/neotron-compute/neotron-os/tree/develop) | [Changes](https://github.com/neotron-compute/neotron-os/compare/v0.8.0...develop))
+## Unreleased changes ([Source](https://github.com/neotron-compute/neotron-os/tree/develop) | [Changes](https://github.com/neotron-compute/neotron-os/compare/v0.8.1...develop))
 
 * None
+
+## v0.8.1 - 2024-05-17 ([Source](https://github.com/neotron-compute/neotron-os/tree/v0.8.1) | [Release](https://github.com/neotron-compute/neotron-os/releases/tag/v0.8.1))
+
+* The `run` command now takes command-line arguments
+* Add `ioctl` API
+* Updated to `neotron-api` v0.2, to provide support for both of the above
+* Add `AUDIO:` device, including `ioctl` to get/set sample rate and get buffer space
+* Implement `fstat` for files (although only file size works)
 
 ## v0.8.0 - 2024-04-11 ([Source](https://github.com/neotron-compute/neotron-os/tree/v0.8.0) | [Release](https://github.com/neotron-compute/neotron-os/releases/tag/v0.8.0))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ checksum = "b9b8634a088b9d5b338a96b3f6ef45a3bc0b9c0f0d562c7d00e498265fd96e8f"
 
 [[package]]
 name = "neotron-os"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "embedded-sdmmc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "b03d7f798bfe97329ad6df937951142eec93886b37d87010502dd25e8cc75fd5"
 
 [[package]]
 name = "neotron-api"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c00f842e7006421002e67a53866b90ddd6f7d86137b52d2147f5e38b35e82f"
+checksum = "67d6c96706b6f3ec069abfb042cadfd2d701980fa4940f407c0bc28ee1e1c493"
 dependencies = [
  "bitflags",
  "neotron-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "0.4", default-features = false }
 embedded-sdmmc = { version = "0.7", default-features = false }
 heapless = "0.7"
 menu = "0.3"
-neotron-api = "0.1"
+neotron-api = "0.2"
 neotron-common-bios = "0.12.0"
 neotron-loader = "0.1"
 pc-keyboard = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neotron-os"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Jonathan 'theJPster' Pallant <github@thejpster.org.uk>",
     "The Neotron Developers"

--- a/src/commands/ram.rs
+++ b/src/commands/ram.rs
@@ -24,10 +24,27 @@ pub static HEXDUMP_ITEM: menu::Item<Ctx> = menu::Item {
 pub static RUN_ITEM: menu::Item<Ctx> = menu::Item {
     item_type: menu::ItemType::Callback {
         function: run,
-        parameters: &[],
+        parameters: &[
+            menu::Parameter::Optional {
+                parameter_name: "arg1",
+                help: None,
+            },
+            menu::Parameter::Optional {
+                parameter_name: "arg2",
+                help: None,
+            },
+            menu::Parameter::Optional {
+                parameter_name: "arg3",
+                help: None,
+            },
+            menu::Parameter::Optional {
+                parameter_name: "arg4",
+                help: None,
+            },
+        ],
     },
     command: "run",
-    help: Some("Jump to start of application area"),
+    help: Some("Run a program (with up to four arguments)"),
 };
 
 pub static LOAD_ITEM: menu::Item<Ctx> = menu::Item {
@@ -90,8 +107,8 @@ fn hexdump(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], _ctx
 }
 
 /// Called when the "run" command is executed.
-fn run(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, _args: &[&str], ctx: &mut Ctx) {
-    match ctx.tpa.execute() {
+fn run(_menu: &menu::Menu<Ctx>, _item: &menu::Item<Ctx>, args: &[&str], ctx: &mut Ctx) {
+    match ctx.tpa.execute(args) {
         Ok(0) => {
             osprintln!();
         }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -110,6 +110,11 @@ impl File {
         FILESYSTEM.file_read(self, buffer)
     }
 
+    /// Write to a file
+    pub fn write(&self, buffer: &[u8]) -> Result<(), Error> {
+        FILESYSTEM.file_write(self, buffer)
+    }
+
     /// Are we at the end of the file
     pub fn is_eof(&self) -> bool {
         FILESYSTEM
@@ -200,6 +205,17 @@ impl Filesystem {
         let fs = fs.as_mut().unwrap();
         let bytes_read = fs.read(file.inner, buffer)?;
         Ok(bytes_read)
+    }
+
+    /// Write to an open file
+    pub fn file_write(&self, file: &File, buffer: &[u8]) -> Result<(), Error> {
+        let mut fs = self.volume_manager.lock();
+        if fs.is_none() {
+            *fs = Some(embedded_sdmmc::VolumeManager::new(BiosBlock(), BiosTime()));
+        }
+        let fs = fs.as_mut().unwrap();
+        fs.write(file.inner, buffer)?;
+        Ok(())
     }
 
     /// How large is a file?


### PR DESCRIPTION
Bump to v0.8.1

* The `run` command now takes command-line arguments
* Add `ioctl` API
* Updated to `neotron-api` v0.2, to provide support for both of the above
* Add `AUDIO:` device, including `ioctl` to get/set sample rate and get buffer space
* Implement `fstat` for files (although only file size works)
